### PR TITLE
Return entire CODAP message response instead of just response.values/response.error.

### DIFF
--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -89,20 +89,8 @@ export const getDataContext = async (dataContextName: string) => {
 };
 
 export const createDataContext = async (dataContextName: string) => {
-  return codapInterface.sendRequest({
-    action:"get",
-    resource: ctxStr(dataContextName)
-    }, function (result: { success: any; }) {
-    if (result && !result.success) {
-      codapInterface.sendRequest({
-        action: "create",
-        resource: "dataContext",
-        values: {
-          name: dataContextName
-        }
-      });
-    }
-  });
+  const res = await sendMessage("create", "dataContext", {name: dataContextName});
+  return res;
 };
 
 export const createDataContextFromURL = async (url: string) => {

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -28,9 +28,9 @@ const createMessage = (action: string, resource: string, values?: any) => {
   };
 };
 
-const sendMessage = async (action: Action, resource: string, values?: CodapItemValues, callback?: (res: IResult) => void) => {
+const sendMessage = (action: Action, resource: string, values?: CodapItemValues, callback?: (res: IResult) => void) => {
   const message = createMessage(action, resource, values);
-  return await codapInterface.sendRequest(message, callback) as unknown as IResult;
+  return codapInterface.sendRequest(message, callback) as unknown as IResult;
 };
 
 ////////////// public API //////////////

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -28,9 +28,9 @@ const createMessage = (action: string, resource: string, values?: any) => {
   };
 };
 
-const sendMessage = (action: Action, resource: string, values?: CodapItemValues, callback?: (res: IResult) => void) => {
+const sendMessage = (action: Action, resource: string, values?: CodapItemValues) => {
   const message = createMessage(action, resource, values);
-  return codapInterface.sendRequest(message, callback) as unknown as IResult;
+  return codapInterface.sendRequest(message) as unknown as IResult;
 };
 
 ////////////// public API //////////////

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -28,9 +28,9 @@ const createMessage = (action: string, resource: string, values?: any) => {
   };
 };
 
-const sendMessage = async (action: Action, resource: string, values?: CodapItemValues, callback?: (res: IResult) => void) => {
+const sendMessage = async (action: Action, resource: string, values?: CodapItemValues) => {
   const message = createMessage(action, resource, values);
-  return await codapInterface.sendRequest(message, callback) as unknown as IResult;
+  return await codapInterface.sendRequest(message) as unknown as IResult;
 };
 
 ////////////// public API //////////////

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -74,6 +74,10 @@ export const selectSelf = () => {
   });
 };
 
+export const addComponentListener = (callback: ClientHandler) => {
+  codapInterface.on("notify", "component", callback);
+};
+
 ////////////// data context functions //////////////
 
 export const getListOfDataContexts = async () => {

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -28,9 +28,9 @@ const createMessage = (action: string, resource: string, values?: any) => {
   };
 };
 
-const sendMessage = (action: Action, resource: string, values?: CodapItemValues) => {
+const sendMessage = async (action: Action, resource: string, values?: CodapItemValues, callback?: (res: IResult) => void) => {
   const message = createMessage(action, resource, values);
-  return codapInterface.sendRequest(message) as unknown as IResult;
+  return await codapInterface.sendRequest(message, callback) as unknown as IResult;
 };
 
 ////////////// public API //////////////
@@ -80,42 +80,41 @@ export const addComponentListener = (callback: ClientHandler) => {
 
 ////////////// data context functions //////////////
 
-export const getListOfDataContexts = async () => {
-  return await sendMessage("get", "dataContextList");
+export const getListOfDataContexts = () => {
+  return sendMessage("get", "dataContextList");
 };
 
-export const getDataContext = async (dataContextName: string) => {
-  return await sendMessage("get", ctxStr(dataContextName));
+export const getDataContext = (dataContextName: string) => {
+  return sendMessage("get", ctxStr(dataContextName));
 };
 
-export const createDataContext = async (dataContextName: string) => {
-  const res = await sendMessage("create", "dataContext", {name: dataContextName});
-  return res;
+export const createDataContext = (dataContextName: string) => {
+  return sendMessage("create", "dataContext", {name: dataContextName});
 };
 
-export const createDataContextFromURL = async (url: string) => {
-  return await sendMessage("create", "dataContextFromURL", {"URL": url});
+export const createDataContextFromURL = (url: string) => {
+  return sendMessage("create", "dataContextFromURL", {"URL": url});
 };
 
-export const addDataContextsListListener = async (callback: ClientHandler) => {
+export const addDataContextsListListener = (callback: ClientHandler) => {
   codapInterface.on("notify", "documentChangeNotice", callback);
 };
 
-export const addDataContextChangeListener = async (context: DataContext, callback: ClientHandler) => {
+export const addDataContextChangeListener = (context: DataContext, callback: ClientHandler) => {
   codapInterface.on("notify", `dataContextChangeNotice[${context.name}]`, callback);
 };
 
 ////////////// collection functions //////////////
 
-export const getCollectionList = async (dataContextName: string) => {
-  return await sendMessage("get", `${ctxStr(dataContextName)}.collectionList`);
+export const getCollectionList = (dataContextName: string) => {
+  return sendMessage("get", `${ctxStr(dataContextName)}.collectionList`);
 };
 
-export const getCollection = async (dataContextName: string, collectionName: string) => {
- return await sendMessage("get", `${ctxStr(dataContextName)}.${collStr(collectionName)}`);
+export const getCollection = (dataContextName: string, collectionName: string) => {
+ return sendMessage("get", `${ctxStr(dataContextName)}.${collStr(collectionName)}`);
 };
 
-export const createParentCollection = async (dataContextName: string, collectionName: string, attrs?: Attribute[]) => {
+export const createParentCollection = (dataContextName: string, collectionName: string, attrs?: Attribute[]) => {
   const resource = `${ctxStr(dataContextName)}.collection`;
 
   const values: CodapItemValues = {
@@ -128,10 +127,10 @@ export const createParentCollection = async (dataContextName: string, collection
     values.attrs = attrs;
   }
 
-  return await sendMessage("create", resource, values);
+  return sendMessage("create", resource, values);
 };
 
-export const createChildCollection = async (dataContextName: string, collectionName: string, parentCollectionName: string, attrs?: Attribute[]) => {
+export const createChildCollection = (dataContextName: string, collectionName: string, parentCollectionName: string, attrs?: Attribute[]) => {
   const resource = `${ctxStr(dataContextName)}.collection`;
 
   const values: CodapItemValues = {
@@ -144,10 +143,10 @@ export const createChildCollection = async (dataContextName: string, collectionN
     values.attrs = attrs;
   }
 
-  return await sendMessage("create", resource, values);
+  return sendMessage("create", resource, values);
 };
 
-export const createNewCollection = async (dataContextName: string, collectionName: string, attrs?: Attribute[]) =>  {
+export const createNewCollection = (dataContextName: string, collectionName: string, attrs?: Attribute[]) =>  {
   const resource = `${ctxStr(dataContextName)}.collection`;
 
   const values: CodapItemValues = {
@@ -159,7 +158,7 @@ export const createNewCollection = async (dataContextName: string, collectionNam
     values.attrs = attrs;
   }
 
-  return await sendMessage("create", resource, values);
+  return sendMessage("create", resource, values);
 };
 
 export const ensureUniqueCollectionName = async (dataContextName: string, collectionName: string, index: number) => {
@@ -185,39 +184,39 @@ export const ensureUniqueCollectionName = async (dataContextName: string, collec
 
 ////////////// attribute functions //////////////
 
-export const getAttribute = async (dataContextName: string, collectionName: string, attributeName: string) => {
+export const getAttribute = (dataContextName: string, collectionName: string, attributeName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attribute[${attributeName}]`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const getAttributeList = async (dataContextName: string, collectionName: string) => {
+export const getAttributeList = (dataContextName: string, collectionName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attributeList`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const createNewAttribute = async (dataContextName: string, collectionName: string, attributeName: string) => {
+export const createNewAttribute = (dataContextName: string, collectionName: string, attributeName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attribute`;
   const values: CodapItemValues = {
     "name": attributeName,
     "title": attributeName,
   };
-  return await sendMessage("create", resource, values);
+  return sendMessage("create", resource, values);
 };
 
-export const updateAttribute = async (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => {
+export const updateAttribute = (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attribute[${attributeName}]`;
-  return await sendMessage("update", resource, values);
+  return sendMessage("update", resource, values);
 };
 
-export const updateAttributePosition = async (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => {
+export const updateAttributePosition = (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attributeLocation[${attrName}]`;
-  return await sendMessage("update", resource, {
+  return sendMessage("update", resource, {
     "collection": collectionName,
     "position": newPosition
   });
 };
 
-export const createCollectionFromAttribute = async (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: string) => {
+export const createCollectionFromAttribute = (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: string) => {
   // check if a collection for the attribute already exists
   const getCollectionMessage = createMessage("get", `${ctxStr(dataContextName)}.${collStr(attr.name)}`);
 
@@ -267,37 +266,37 @@ export const createCollectionFromAttribute = async (dataContextName: string, old
 
 ////////////// case functions //////////////
 
-export const getCaseCount = async (dataContextName: string, collectionName: string) => {
+export const getCaseCount = (dataContextName: string, collectionName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseCount`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const getCaseByIndex = async (dataContextName: string, collectionName: string, index: number) => {
+export const getCaseByIndex = (dataContextName: string, collectionName: string, index: number) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseByIndex[${index}]`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const getCaseByID = async (dataContextName: string, caseID: number | string) => {
+export const getCaseByID = (dataContextName: string, caseID: number | string) => {
   const resource = `${ctxStr(dataContextName)}.caseByID[${caseID}]`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const getCaseBySearch = async (dataContextName: string, collectionName: string, search: string) => {
+export const getCaseBySearch = (dataContextName: string, collectionName: string, search: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseSearch[${search}]`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const getCaseByFormulaSearch = async (dataContextName: string, collectionName: string, search: string) => {
+export const getCaseByFormulaSearch = (dataContextName: string, collectionName: string, search: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseFormulaSearch[${search}]`;
-  return await sendMessage("get", resource);
+  return sendMessage("get", resource);
 };
 
-export const createSingleOrParentCase = async (dataContextName: string, collectionName: string, values: Array<CodapItemValues>) => {
+export const createSingleOrParentCase = (dataContextName: string, collectionName: string, values: Array<CodapItemValues>) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.case`;
-  return await sendMessage("create", resource, values);
+  return sendMessage("create", resource, values);
 };
 
-export const createChildCase = async (dataContextName: string, collectionName: string, parentCaseID: number | string, values: CodapItemValues) => {
+export const createChildCase = (dataContextName: string, collectionName: string, parentCaseID: number | string, values: CodapItemValues) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.case`;
   const valuesWithParent = [
     {
@@ -305,64 +304,64 @@ export const createChildCase = async (dataContextName: string, collectionName: s
       values
     }
   ];
-  return await sendMessage("create", resource, valuesWithParent);
+  return sendMessage("create", resource, valuesWithParent);
 };
 
-export const updateCaseById = async (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
+export const updateCaseById = (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
   const resource = `${ctxStr(dataContextName)}.caseByID[${caseID}]`;
   const updateValues = {
     values
   };
-  return await sendMessage("update", resource, updateValues);
+  return sendMessage("update", resource, updateValues);
 };
 
-export const updateCases = async (dataContextName: string, collectionName: string, values: CodapItem[]) => {
+export const updateCases = (dataContextName: string, collectionName: string, values: CodapItem[]) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.case`;
-  return await sendMessage("update", resource, values);
+  return sendMessage("update", resource, values);
 };
 
-export const selectCases = async (dataContextName: string, caseIds: string[]) => {
-  return await sendMessage("create", `${ctxStr(dataContextName)}.selectionList`, caseIds);
+export const selectCases = (dataContextName: string, caseIds: string[]) => {
+  return sendMessage("create", `${ctxStr(dataContextName)}.selectionList`, caseIds);
 };
 
 ////////////// item functions //////////////
 
-export const getItemCount = async (dataContextName: string) => {
-  return await sendMessage("get", `${ctxStr(dataContextName)}.itemCount`);
+export const getItemCount = (dataContextName: string) => {
+  return sendMessage("get", `${ctxStr(dataContextName)}.itemCount`);
 };
 
-export const getAllItems = async (dataContextName: string) =>{
-  return await sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[*]`);
+export const getAllItems = (dataContextName: string) =>{
+  return sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[*]`);
 };
 
-export const getItemByID = async (dataContextName: string, itemID: number | string) => {
-  return await sendMessage("get", `${ctxStr(dataContextName)}.itemByID[${itemID}]`);
+export const getItemByID = (dataContextName: string, itemID: number | string) => {
+  return sendMessage("get", `${ctxStr(dataContextName)}.itemByID[${itemID}]`);
 };
 
-export const getItemByIndex = async (dataContextName: string, index: number) => {
-  return await sendMessage("get", `${ctxStr(dataContextName)}.item[${index}]`);
+export const getItemByIndex = (dataContextName: string, index: number) => {
+  return sendMessage("get", `${ctxStr(dataContextName)}.item[${index}]`);
 };
 
-export const getItemByCaseID = async (dataContextName: string, caseID: number | string) => {
-  return await sendMessage("get", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`);
+export const getItemByCaseID = (dataContextName: string, caseID: number | string) => {
+  return sendMessage("get", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`);
 };
 
-export const getItemBySearch = async (dataContextName: string, search: string) => {
-  return await sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[${search}]`);
+export const getItemBySearch = (dataContextName: string, search: string) => {
+  return sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[${search}]`);
 };
 
-export const createItems = async (dataContextName: string, items: Array<CodapItemValues>) => {
-  return await sendMessage("create", `${ctxStr(dataContextName)}.item`, items);
+export const createItems = (dataContextName: string, items: Array<CodapItemValues>) => {
+  return sendMessage("create", `${ctxStr(dataContextName)}.item`, items);
 };
 
-export const updateItemByID = async (dataContextName: string, itemID: number | string, values: CodapItemValues) => {
-  return await sendMessage("update", `${ctxStr(dataContextName)}.itemByID[${itemID}]`, values);
+export const updateItemByID = (dataContextName: string, itemID: number | string, values: CodapItemValues) => {
+  return sendMessage("update", `${ctxStr(dataContextName)}.itemByID[${itemID}]`, values);
 };
 
-export const updateItemByIndex = async (dataContextName: string, index: number, values: CodapItemValues) => {
-  return await sendMessage("update", `${ctxStr(dataContextName)}.item[${index}]`, values);
+export const updateItemByIndex = (dataContextName: string, index: number, values: CodapItemValues) => {
+  return sendMessage("update", `${ctxStr(dataContextName)}.item[${index}]`, values);
 };
 
-export const updateItemByCaseID = async (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
-  return await sendMessage("update", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`, values);
+export const updateItemByCaseID = (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
+  return sendMessage("update", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`, values);
 };

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -28,20 +28,9 @@ const createMessage = (action: string, resource: string, values?: any) => {
   };
 };
 
-const sendMessage = (action: Action, resource: string, values?: CodapItemValues) => {
+const sendMessage = async (action: Action, resource: string, values?: CodapItemValues, callback?: (res: IResult) => void) => {
   const message = createMessage(action, resource, values);
-  return new Promise((resolve, reject) => {
-    codapInterface.sendRequest(message, (result: IResult) => {
-      if (!result) {
-        reject("Request timeout");
-      } else if (result?.success) {
-        resolve(result.values);
-      } else {
-        const error_message = (result?.values?.error) ?? "unknown error";
-        reject(error_message);
-      }
-    });
-  });
+  return await codapInterface.sendRequest(message, callback) as unknown as IResult;
 };
 
 ////////////// public API //////////////
@@ -58,14 +47,8 @@ export const initializePlugin = (options: IInitializePlugin) => {
 
 ////////////// component functions //////////////
 
-export const createTable = () => {
-  codapInterface.sendRequest({
-    action: "create",
-    resource: "component",
-    values: {
-      type: "caseTable"
-    }
-  });
+export const createTable = async () => {
+  return await sendMessage("create", "component", { type: "caseTable" });
 };
 
 // Selects this component. In CODAP this will bring this component to the front.
@@ -93,15 +76,15 @@ export const selectSelf = () => {
 
 ////////////// data context functions //////////////
 
-export const getListOfDataContexts = () => {
-  return sendMessage("get", "dataContextList");
+export const getListOfDataContexts = async () => {
+  return await sendMessage("get", "dataContextList");
 };
 
-export const getDataContext = (dataContextName: string) => {
-  return sendMessage("get", ctxStr(dataContextName));
+export const getDataContext = async (dataContextName: string) => {
+  return await sendMessage("get", ctxStr(dataContextName));
 };
 
-export const createDataContext = (dataContextName: string) => {
+export const createDataContext = async (dataContextName: string) => {
   return codapInterface.sendRequest({
     action:"get",
     resource: ctxStr(dataContextName)
@@ -118,29 +101,29 @@ export const createDataContext = (dataContextName: string) => {
   });
 };
 
-export const createDataContextFromURL = (url: string) => {
-  return sendMessage("create", "dataContextFromURL", {"URL": url});
+export const createDataContextFromURL = async (url: string) => {
+  return await sendMessage("create", "dataContextFromURL", {"URL": url});
 };
 
-export const addDataContextsListListener = (callback: ClientHandler) => {
+export const addDataContextsListListener = async (callback: ClientHandler) => {
   codapInterface.on("notify", "documentChangeNotice", callback);
 };
 
-export const addDataContextChangeListener = (context: DataContext, callback: ClientHandler) => {
+export const addDataContextChangeListener = async (context: DataContext, callback: ClientHandler) => {
   codapInterface.on("notify", `dataContextChangeNotice[${context.name}]`, callback);
 };
 
 ////////////// collection functions //////////////
 
-export const getCollectionList = (dataContextName: string) => {
-  return sendMessage("get", `${ctxStr(dataContextName)}.collectionList`);
+export const getCollectionList = async (dataContextName: string) => {
+  return await sendMessage("get", `${ctxStr(dataContextName)}.collectionList`);
 };
 
-export const getCollection = (dataContextName: string, collectionName: string) => {
- return sendMessage("get", `${ctxStr(dataContextName)}.${collStr(collectionName)}`);
+export const getCollection = async (dataContextName: string, collectionName: string) => {
+ return await sendMessage("get", `${ctxStr(dataContextName)}.${collStr(collectionName)}`);
 };
 
-export const createParentCollection = (dataContextName: string, collectionName: string, attrs?: Attribute[]) => {
+export const createParentCollection = async (dataContextName: string, collectionName: string, attrs?: Attribute[]) => {
   const resource = `${ctxStr(dataContextName)}.collection`;
 
   const values: CodapItemValues = {
@@ -153,10 +136,10 @@ export const createParentCollection = (dataContextName: string, collectionName: 
     values.attrs = attrs;
   }
 
-  return sendMessage("create", resource, values);
+  return await sendMessage("create", resource, values);
 };
 
-export const createChildCollection = (dataContextName: string, collectionName: string, parentCollectionName: string, attrs?: Attribute[]) => {
+export const createChildCollection = async (dataContextName: string, collectionName: string, parentCollectionName: string, attrs?: Attribute[]) => {
   const resource = `${ctxStr(dataContextName)}.collection`;
 
   const values: CodapItemValues = {
@@ -169,10 +152,10 @@ export const createChildCollection = (dataContextName: string, collectionName: s
     values.attrs = attrs;
   }
 
-  return sendMessage("create", resource, values);
+  return await sendMessage("create", resource, values);
 };
 
-export const createNewCollection = (dataContextName: string, collectionName: string, attrs?: Attribute[]) =>  {
+export const createNewCollection = async (dataContextName: string, collectionName: string, attrs?: Attribute[]) =>  {
   const resource = `${ctxStr(dataContextName)}.collection`;
 
   const values: CodapItemValues = {
@@ -184,10 +167,10 @@ export const createNewCollection = (dataContextName: string, collectionName: str
     values.attrs = attrs;
   }
 
-  return sendMessage("create", resource, values);
+  return await sendMessage("create", resource, values);
 };
 
-export const ensureUniqueCollectionName = (dataContextName: string, collectionName: string, index: number) => {
+export const ensureUniqueCollectionName = async (dataContextName: string, collectionName: string, index: number) => {
   index = index || 0;
   const uniqueName = `${collectionName}${index ? index : ""}`;
   const getCollMessage = {
@@ -210,39 +193,39 @@ export const ensureUniqueCollectionName = (dataContextName: string, collectionNa
 
 ////////////// attribute functions //////////////
 
-export const getAttribute = (dataContextName: string, collectionName: string, attributeName: string) => {
+export const getAttribute = async (dataContextName: string, collectionName: string, attributeName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attribute[${attributeName}]`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const getAttributeList = (dataContextName: string, collectionName: string) => {
+export const getAttributeList = async (dataContextName: string, collectionName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attributeList`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const createNewAttribute = (dataContextName: string, collectionName: string, attributeName: string) => {
+export const createNewAttribute = async (dataContextName: string, collectionName: string, attributeName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attribute`;
   const values: CodapItemValues = {
     "name": attributeName,
     "title": attributeName,
   };
-  return sendMessage("create", resource, values);
+  return await sendMessage("create", resource, values);
 };
 
-export const updateAttribute = (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => {
+export const updateAttribute = async (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attribute[${attributeName}]`;
-  return sendMessage("update", resource, values);
+  return await sendMessage("update", resource, values);
 };
 
-export const updateAttributePosition = (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => {
+export const updateAttributePosition = async (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.attributeLocation[${attrName}]`;
-  return sendMessage("update", resource, {
+  return await sendMessage("update", resource, {
     "collection": collectionName,
     "position": newPosition
   });
 };
 
-export const createCollectionFromAttribute = (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: string) => {
+export const createCollectionFromAttribute = async (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: string) => {
   // check if a collection for the attribute already exists
   const getCollectionMessage = createMessage("get", `${ctxStr(dataContextName)}.${collStr(attr.name)}`);
 
@@ -292,37 +275,37 @@ export const createCollectionFromAttribute = (dataContextName: string, oldCollec
 
 ////////////// case functions //////////////
 
-export const getCaseCount = (dataContextName: string, collectionName: string) => {
+export const getCaseCount = async (dataContextName: string, collectionName: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseCount`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const getCaseByIndex = (dataContextName: string, collectionName: string, index: number) => {
+export const getCaseByIndex = async (dataContextName: string, collectionName: string, index: number) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseByIndex[${index}]`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const getCaseByID = (dataContextName: string, caseID: number | string) => {
+export const getCaseByID = async (dataContextName: string, caseID: number | string) => {
   const resource = `${ctxStr(dataContextName)}.caseByID[${caseID}]`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const getCaseBySearch = (dataContextName: string, collectionName: string, search: string) => {
+export const getCaseBySearch = async (dataContextName: string, collectionName: string, search: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseSearch[${search}]`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const getCaseByFormulaSearch = (dataContextName: string, collectionName: string, search: string) => {
+export const getCaseByFormulaSearch = async (dataContextName: string, collectionName: string, search: string) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.caseFormulaSearch[${search}]`;
-  return sendMessage("get", resource);
+  return await sendMessage("get", resource);
 };
 
-export const createSingleOrParentCase = (dataContextName: string, collectionName: string, values: Array<CodapItemValues>) => {
+export const createSingleOrParentCase = async (dataContextName: string, collectionName: string, values: Array<CodapItemValues>) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.case`;
-  return sendMessage("create", resource, values);
+  return await sendMessage("create", resource, values);
 };
 
-export const createChildCase = (dataContextName: string, collectionName: string, parentCaseID: number | string, values: CodapItemValues) => {
+export const createChildCase = async (dataContextName: string, collectionName: string, parentCaseID: number | string, values: CodapItemValues) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.case`;
   const valuesWithParent = [
     {
@@ -330,64 +313,64 @@ export const createChildCase = (dataContextName: string, collectionName: string,
       values
     }
   ];
-  return sendMessage("create", resource, valuesWithParent);
+  return await sendMessage("create", resource, valuesWithParent);
 };
 
-export const updateCaseById = (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
+export const updateCaseById = async (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
   const resource = `${ctxStr(dataContextName)}.caseByID[${caseID}]`;
   const updateValues = {
     values
   };
-  return sendMessage("update", resource, updateValues);
+  return await sendMessage("update", resource, updateValues);
 };
 
-export const updateCases = (dataContextName: string, collectionName: string, values: CodapItem[]) => {
+export const updateCases = async (dataContextName: string, collectionName: string, values: CodapItem[]) => {
   const resource = `${ctxStr(dataContextName)}.${collStr(collectionName)}.case`;
-  return sendMessage("update", resource, values);
+  return await sendMessage("update", resource, values);
 };
 
-export const selectCases = (dataContextName: string, caseIds: string[]) => {
-  return sendMessage("create", `${ctxStr(dataContextName)}.selectionList`, caseIds);
+export const selectCases = async (dataContextName: string, caseIds: string[]) => {
+  return await sendMessage("create", `${ctxStr(dataContextName)}.selectionList`, caseIds);
 };
 
 ////////////// item functions //////////////
 
-export const getItemCount = (dataContextName: string) => {
-  return sendMessage("get", `${ctxStr(dataContextName)}.itemCount`);
+export const getItemCount = async (dataContextName: string) => {
+  return await sendMessage("get", `${ctxStr(dataContextName)}.itemCount`);
 };
 
-export const getAllItems = (dataContextName: string) =>{
-  return sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[*]`);
+export const getAllItems = async (dataContextName: string) =>{
+  return await sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[*]`);
 };
 
-export const getItemByID = (dataContextName: string, itemID: number | string) => {
-  return sendMessage("get", `${ctxStr(dataContextName)}.itemByID[${itemID}]`);
+export const getItemByID = async (dataContextName: string, itemID: number | string) => {
+  return await sendMessage("get", `${ctxStr(dataContextName)}.itemByID[${itemID}]`);
 };
 
-export const getItemByIndex = (dataContextName: string, index: number) => {
-  return sendMessage("get", `${ctxStr(dataContextName)}.item[${index}]`);
+export const getItemByIndex = async (dataContextName: string, index: number) => {
+  return await sendMessage("get", `${ctxStr(dataContextName)}.item[${index}]`);
 };
 
-export const getItemByCaseID = (dataContextName: string, caseID: number | string) => {
-  return sendMessage("get", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`);
+export const getItemByCaseID = async (dataContextName: string, caseID: number | string) => {
+  return await sendMessage("get", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`);
 };
 
-export const getItemBySearch = (dataContextName: string, search: string) => {
-  return sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[${search}]`);
+export const getItemBySearch = async (dataContextName: string, search: string) => {
+  return await sendMessage("get", `${ctxStr(dataContextName)}.itemSearch[${search}]`);
 };
 
-export const createItems = (dataContextName: string, items: Array<CodapItemValues>) => {
-  return sendMessage("create", `${ctxStr(dataContextName)}.item`, items);
+export const createItems = async (dataContextName: string, items: Array<CodapItemValues>) => {
+  return await sendMessage("create", `${ctxStr(dataContextName)}.item`, items);
 };
 
-export const updateItemByID = (dataContextName: string, itemID: number | string, values: CodapItemValues) => {
-  return sendMessage("update", `${ctxStr(dataContextName)}.itemByID[${itemID}]`, values);
+export const updateItemByID = async (dataContextName: string, itemID: number | string, values: CodapItemValues) => {
+  return await sendMessage("update", `${ctxStr(dataContextName)}.itemByID[${itemID}]`, values);
 };
 
-export const updateItemByIndex = (dataContextName: string, index: number, values: CodapItemValues) => {
-  return sendMessage("update", `${ctxStr(dataContextName)}.item[${index}]`, values);
+export const updateItemByIndex = async (dataContextName: string, index: number, values: CodapItemValues) => {
+  return await sendMessage("update", `${ctxStr(dataContextName)}.item[${index}]`, values);
 };
 
-export const updateItemByCaseID = (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
-  return sendMessage("update", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`, values);
+export const updateItemByCaseID = async (dataContextName: string, caseID: number | string, values: CodapItemValues) => {
+  return await sendMessage("update", `${ctxStr(dataContextName)}.itemByCaseID[${caseID}]`, values);
 };


### PR DESCRIPTION
The decision to make this change came from working with Evangeline on the `codap-plugin-starter-project`. Initially the `sendMessage` function was copied from the original `codap-plugin-starter-project` code, but we realized that, at least for the purposes of the starter plugin, we wanted to grab the whole response from the `sendRequest` function, not only the resolved values / rejected error, in order to display the entire response message in the UI.

I'm not sure whether or not this is the best approach, as it puts the responsibility to implement error handling on the user of the API. 

Also, there is a weird thing where in order for the API to work, we had to add async + awaits to all of the functions in the API that call `sendMessage`, but not to `sendMessage` itself. If we added async + await to sendMessage, we did not get the responses we expected in the `codap-plugin-starter-project `(see code implemented in the plugin [here](https://github.com/concord-consortium/codap-plugin-starter-project/blob/type-send-message/src/components/App.tsx#L46)).