### PR TITLE
Release 0.2.0: don't fail a slow CODAP request; standardize callback contract [SAMPLER-107]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,37 @@
 # Changelog
 
-### Asset Sizes
+## 0.2.0
 
-| File | Size | % Increase from Previous Release |
-|---|---|---|
-| index.css | x bytes | n/a |
-| index.js | y bytes | n/a |
+### Changed
 
+- **A request now waits up to 60 seconds for a CODAP response, rather than about 2 seconds.**
+  iframe-phone's 2s timer reports that no reply has arrived yet; it does not cancel the request,
+  and the real reply still arrives afterwards. Treating it as a failure meant a large request —
+  creating several thousand items, say — was reported as failed while the result that was about to
+  arrive was discarded. A plugin with its own "taking too long" UI tuned to the old ~2s rejection
+  will now wait longer before its error path runs; `setRequestTimeout()` can restore a shorter
+  deadline.
+- **A callback passed to `sendRequest` is now invoked exactly once, on every outcome**: with the
+  response on success, and with `undefined` when CODAP did not respond. Previously a request that
+  took longer than iframe-phone's 2s timer invoked the callback twice — once with `undefined` when
+  the timer expired, and again with the real reply when it arrived. Callbacks written as
+  `result.success` therefore threw a `TypeError` at the 2s mark before succeeding normally.
+- **`sendRequest` rejects when there is no connection**, rather than leaving the promise pending
+  forever. Calling it before `initializePlugin()` now reports a failure instead of doing nothing.
+- `init()` still fails fast: the handshake rejects as soon as nothing answers it, so a plugin
+  loaded outside CODAP finds out in seconds rather than after the full request timeout.
+
+### Added
+
+- `codapInterface.getRequestTimeout()` and `codapInterface.setRequestTimeout(ms)`.
+
+### Fixed
+
+- **Request failures inside the bundled helpers are reported rather than thrown.** `selectSelf`,
+  `createCollectionFromAttribute` and `ensureUniqueCollectionName` read `.success` off the
+  response, so a request that went unanswered previously surfaced as a `TypeError` — and, where the
+  promise was discarded, an unhandled rejection. They now log a warning and return.
+  `ensureUniqueCollectionName` still rejects, since a lookup that gets no answer says nothing about
+  whether the name is free, but with a descriptive message rather than a `TypeError`.
+- `stats.timeDiFirstReq` was never set; each data-interactive request overwrote
+  `stats.timeCodapFirstReq` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   forever, a silent no-op. It now rejects. Since the documented pattern of passing a callback and
   discarding the promise leaves nothing attached to observe that, an unhandled rejection appears
   where nothing happened before. Attach a `.catch`, even when the callback is doing the real work.
-- **A reply from CODAP with no value now fails the request** rather than waiting out the deadline.
-  It resolves nothing, because there is no result for the caller to read; resolving with `undefined`
-  would hand a caller something `result.success` throws on.
+- **An exception thrown by `init()`'s `stateHandler` or callback no longer prevents it from
+  settling.** They were invoked before the handshake's promise was resolved, so a throw from one left
+  `initializePlugin()` pending forever with the exception discarded. They are now invoked after it
+  settles, and what they throw is reported the same way a request callback's exception is.
 - **An exception thrown by a request callback is rethrown as an uncaught error** rather than being
   swallowed. The request has already settled by the time its callback runs, so a throw from it is a
   bug in the callback rather than a failure of the request — but it must not escape into the stack
@@ -69,6 +70,10 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   deadline.
 - `init()` still fails fast: the handshake rejects as soon as nothing answers it, so a plugin
   loaded outside CODAP finds out in seconds rather than after the full request timeout.
+- A reply from CODAP carrying no value still fails the request immediately, as it did before, and is
+  not left to wait out the new deadline. Keeping that took distinguishing it from iframe-phone's
+  advisory timer, which reports itself the same way — with `undefined` — and differs only in a second
+  argument the library passes for the timer alone. A `null` reply is treated the same way.
 - `destroy()` now reports the connection as `closed`, so `getConnectionState()` is accurate after
   teardown and requests issued afterwards are refused rather than reaching a null connection.
   Calling `init()` again reconnects, as before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## 0.2.0
 
+### Breaking
+
+Each of these changes what an existing caller sees, which is why this is a minor bump rather than a
+patch: for a `0.x` package npm's caret resolves `^0.1.9` to `<0.2.0`, so a consumer picks these up
+only by moving to `^0.2.0` deliberately, rather than silently on their next install.
+
+- **A callback passed to `sendRequest` is now invoked exactly once, on every outcome**: with the
+  response on success, and with `undefined` when the request failed. Previously a request that took
+  longer than iframe-phone's 2s timer invoked the callback twice — once with `undefined` when the
+  timer expired, and again with the real reply when it arrived — and on failures where nothing ever
+  replied it was not invoked at all. A callback written as `result.success` therefore threw a
+  `TypeError` at the 2s mark before succeeding normally, and a callback relying on being told about
+  failure never was. Callbacks now need to handle `undefined`, which is the shape of a failure.
+- **A failed request rejects with an `Error`**, where it previously rejected with a string. Anything
+  matching on the rejection value (`error.startsWith(...)`, `error === "..."`) needs updating; the
+  message text is unchanged, so `String(error)` and `error.message` carry what the string did.
+- **`sendRequest` rejects on paths that previously never settled at all.** With no connection —
+  before `initializePlugin()` or after `destroy()` — it used to return a promise that stayed pending
+  forever, a silent no-op. It now rejects. Since the documented pattern of passing a callback and
+  discarding the promise leaves nothing attached to observe that, an unhandled rejection appears
+  where nothing happened before. Attach a `.catch`, even when the callback is doing the real work.
+- **A reply from CODAP with no value now fails the request** rather than waiting out the deadline.
+  It resolves nothing, because there is no result for the caller to read; resolving with `undefined`
+  would hand a caller something `result.success` throws on.
+- **An exception thrown by a request callback is rethrown as an uncaught error** rather than being
+  swallowed. The request has already settled by the time its callback runs, so a throw from it is a
+  bug in the callback rather than a failure of the request — but it must not escape into the stack
+  that invoked it either. It is rethrown from a microtask: clear of iframe-phone's message listener
+  (where a throw skipped that library's own bookkeeping), clear of the deadline timer, and clear of
+  the promise executor (which discarded it silently once the promise had settled), while still
+  reaching `window.onerror` and error reporters. This covers an `async` callback, whose throw
+  arrives as a rejected return value that a `try`/`catch` around the call cannot see. The loudness
+  is deliberate: a callback that throws on `undefined` is the `TypeError` described above, and it is
+  the bug this release most wants consumers to find.
+- **`createCollectionFromAttribute` reports whether the reorganization happened.** It ran on nested
+  callbacks and returned the promise of its first request — the collection lookup — so it resolved
+  while the steps that create the collection and move the attribute into it were still outstanding,
+  and their failures reached the caller as nothing at all. It now awaits each step and resolves with
+  an `IResult` for the last one it reached: the move on success, or the step CODAP refused. Two
+  consequences for callers. The resolved value is different — previously the lookup's reply, which
+  was `{success: false}` in the common case where no such collection existed yet. And **the promise
+  can now reject**, where before an inner failure could never reject it, since it was the lookup's
+  already-settled promise: an `await` with no `try`/`catch` that could not throw now can. Its
+  declared return type narrows from `Promise<unknown>` to `Promise<IResult>`, which is
+  source-compatible for anyone casting the result.
+
 ### Changed
 
 - **A request now waits up to 60 seconds for a CODAP response, rather than about 2 seconds.**
@@ -11,33 +57,19 @@
   arrive was discarded. A plugin with its own "taking too long" UI tuned to the old ~2s rejection
   will now wait longer before its error path runs; `setRequestTimeout()` can restore a shorter
   deadline.
-- **A callback passed to `sendRequest` is now invoked exactly once, on every outcome**: with the
-  response on success, and with `undefined` when CODAP did not respond. Previously a request that
-  took longer than iframe-phone's 2s timer invoked the callback twice — once with `undefined` when
-  the timer expired, and again with the real reply when it arrived. Callbacks written as
-  `result.success` therefore threw a `TypeError` at the 2s mark before succeeding normally.
-- **`sendRequest` rejects when there is no connection**, rather than leaving the promise pending
-  forever. Calling it before `initializePlugin()` now reports a failure instead of doing nothing.
-- **An exception thrown by a request callback is rethrown on a fresh task.** The request has
-  already settled by the time its callback runs, so a throw from it is a bug in the callback rather
-  than a failure of the request, and it must not escape into the stack that invoked it. Previously
-  it did: on the reply path it propagated into iframe-phone's message listener, skipping that
-  library's own bookkeeping, while on other paths it was discarded without a trace. It now reaches
-  `window.onerror` and error reporters on every path, including from an `async` callback, whose
-  throw a `try`/`catch` around the call cannot see.
 - `init()` still fails fast: the handshake rejects as soon as nothing answers it, so a plugin
   loaded outside CODAP finds out in seconds rather than after the full request timeout.
-- **`createCollectionFromAttribute` now reports whether the reorganization happened.** It ran on
-  nested callbacks and resolved with the reply to its first request — the collection lookup — so it
-  reported success while the steps that create the collection and move the attribute into it were
-  still outstanding, and their failures reached the caller as nothing at all. It now awaits each
-  step and resolves with an `IResult` for the last one it reached: the move on success, or the step
-  CODAP refused. A request that goes unanswered rejects, as it does elsewhere in the helpers. Its
-  declared return type changes from `Promise<unknown>` to `Promise<IResult>`.
+- `destroy()` now reports the connection as `closed`, so `getConnectionState()` is accurate after
+  teardown and requests issued afterwards are refused rather than reaching a null connection.
+  Calling `init()` again reconnects, as before.
 
 ### Added
 
 - `codapInterface.getRequestTimeout()` and `codapInterface.setRequestTimeout(ms)`.
+- `stats.countDiReqDeadlineExceeded`, the number of requests that ran out of time. `getStats()`
+  previously reported no counter for them at all, while `countDiRplTimeout` counts iframe-phone's
+  advisory probe — which fires for every request slower than 2s and so is expected to be non-zero on
+  a plugin doing bulk work. Both are documented in the published type declarations.
 
 ### Fixed
 
@@ -45,8 +77,11 @@
   `createCollectionFromAttribute` and `ensureUniqueCollectionName` read `.success` off the
   response, so a request that went unanswered previously surfaced as a `TypeError` — and, where the
   promise was discarded, an unhandled rejection. `selectSelf` now logs a warning, since it is
-  fire-and-forget and has no caller waiting on an answer. The other two reject with a descriptive
-  message: a lookup that gets no answer says nothing about whether the name is free or the
-  collection exists, and that is the caller's to decide.
+  fire-and-forget and has no caller waiting on an answer, and it no longer asks CODAP to select
+  `component[undefined]` when the frame comes back without an id. The other two reject with a
+  descriptive message: a lookup that gets no answer says nothing about whether the name is free or
+  the collection exists, and that is the caller's to decide.
+- A reply arriving after its request had already failed no longer marks the connection active or
+  counts a success against it.
 - `stats.timeDiFirstReq` was never set; each data-interactive request overwrote
   `stats.timeCodapFirstReq` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   names every callback that no longer matches the expected signature, at the moment of upgrading,
   instead of leaving each one to throw on a failure path that may be rare in testing and common in
   use. A callback that already handled absence needs nothing; one that did not needs its parameter
-  widened to `(result?: IResult)`. Anything
+  widened to `(result?: IResult)`.
+
+  The required shape follows from the message. CODAP answers a batched request — an array of requests
+  — with an array of results, so that case takes `BatchRequestCallback` (also exported) and passing a
+  single-result callback with an array message, or the reverse, does not compile. A callback can
+  therefore never be handed a response it cannot read: previously `sendRequest([a, b], cb)` compiled
+  and gave `cb` an array, where reading `result.success` yielded `undefined` and a successful batch
+  looked like a failed one. Anything
   matching on the rejection value (`error.startsWith(...)`, `error === "..."`) needs updating, and
   `error.message` is where the text now lives — note that `String(error)` prefixes it with `Error: `.
   Some of the text changed too: a request that outlives its deadline now reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,12 +67,22 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   already-settled promise: an `await` with no `try`/`catch` that could not throw now can. Its
   declared return type narrows from `Promise<unknown>` to `Promise<IResult>`, which is
   source-compatible for anyone casting the result.
-- **A failed `init()` handshake now closes the connection**, and its optional callback is invoked
-  with `undefined` rather than being skipped. Previously a handshake that drew no reply left a
-  connection object behind that nothing was listening to, so every subsequent request was sent and
-  then waited out the full deadline — a minute apiece for a plugin that had already been told it was
-  not running inside CODAP. Those requests are now refused at once. `init()` can be called again to
-  retry, and it rejects with an `Error` like every other failure.
+- **`ensureUniqueCollectionName` checks its attempt limit before issuing a lookup rather than after.**
+  Callers using the documented entry point, `index = 0`, are unaffected: the candidates are still
+  `collectionName` through `collectionName100` and the request count is unchanged. A caller passing an
+  `index` above 100 directly now gets `undefined` without a request being issued, where it previously
+  issued the lookup and returned the name if it was free.
+- **A handshake that nothing answers now closes the connection**, and `init()`'s optional callback is
+  invoked with `undefined` rather than being skipped. Such a handshake used to leave an endpoint
+  behind that nothing was listening to, so every subsequent request was sent and then waited out the
+  full deadline — a minute apiece for a plugin already told it was not running inside CODAP. Those
+  requests are now refused at once. `init()` can be called again to retry, and it rejects with an
+  `Error` like every other failure.
+
+  Only silence closes the connection. A handshake CODAP *answers* and declines leaves it open, since
+  CODAP is evidently there and listening; only the handshake fails. And a handshake closes only the
+  endpoint it created, so of two overlapping `init()` calls — which React's StrictMode produces from
+  a single effect — the one that fails cannot close the connection the other established.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,22 @@
   `result.success` therefore threw a `TypeError` at the 2s mark before succeeding normally.
 - **`sendRequest` rejects when there is no connection**, rather than leaving the promise pending
   forever. Calling it before `initializePlugin()` now reports a failure instead of doing nothing.
+- **An exception thrown by a request callback is rethrown on a fresh task.** The request has
+  already settled by the time its callback runs, so a throw from it is a bug in the callback rather
+  than a failure of the request, and it must not escape into the stack that invoked it. Previously
+  it did: on the reply path it propagated into iframe-phone's message listener, skipping that
+  library's own bookkeeping, while on other paths it was discarded without a trace. It now reaches
+  `window.onerror` and error reporters on every path, including from an `async` callback, whose
+  throw a `try`/`catch` around the call cannot see.
 - `init()` still fails fast: the handshake rejects as soon as nothing answers it, so a plugin
   loaded outside CODAP finds out in seconds rather than after the full request timeout.
+- **`createCollectionFromAttribute` now reports whether the reorganization happened.** It ran on
+  nested callbacks and resolved with the reply to its first request — the collection lookup — so it
+  reported success while the steps that create the collection and move the attribute into it were
+  still outstanding, and their failures reached the caller as nothing at all. It now awaits each
+  step and resolves with an `IResult` for the last one it reached: the move on success, or the step
+  CODAP refused. A request that goes unanswered rejects, as it does elsewhere in the helpers. Its
+  declared return type changes from `Promise<unknown>` to `Promise<IResult>`.
 
 ### Added
 
@@ -30,8 +44,9 @@
 - **Request failures inside the bundled helpers are reported rather than thrown.** `selectSelf`,
   `createCollectionFromAttribute` and `ensureUniqueCollectionName` read `.success` off the
   response, so a request that went unanswered previously surfaced as a `TypeError` — and, where the
-  promise was discarded, an unhandled rejection. They now log a warning and return.
-  `ensureUniqueCollectionName` still rejects, since a lookup that gets no answer says nothing about
-  whether the name is free, but with a descriptive message rather than a `TypeError`.
+  promise was discarded, an unhandled rejection. `selectSelf` now logs a warning, since it is
+  fire-and-forget and has no caller waiting on an answer. The other two reject with a descriptive
+  message: a lookup that gets no answer says nothing about whether the name is free or the
+  collection exists, and that is the caller's to decide.
 - `stats.timeDiFirstReq` was never set; each data-interactive request overwrote
   `stats.timeCodapFirstReq` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   single-result callback with an array message, or the reverse, does not compile. A callback can
   therefore never be handed a response it cannot read: previously `sendRequest([a, b], cb)` compiled
   and gave `cb` an array, where reading `result.success` yielded `undefined` and a successful batch
-  looked like a failed one. Anything
+  looked like a failed one.
+- **A failed request rejects with an `Error`**, where it previously rejected with a string. Anything
   matching on the rejection value (`error.startsWith(...)`, `error === "..."`) needs updating, and
   `error.message` is where the text now lives — note that `String(error)` prefixes it with `Error: `.
   Some of the text changed too: a request that outlives its deadline now reports
@@ -66,7 +67,6 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   already-settled promise: an `await` with no `try`/`catch` that could not throw now can. Its
   declared return type narrows from `Promise<unknown>` to `Promise<IResult>`, which is
   source-compatible for anyone casting the result.
-
 - **A failed `init()` handshake now closes the connection**, and its optional callback is invoked
   with `undefined` rather than being skipped. Previously a handshake that drew no reply left a
   connection object behind that nothing was listening to, so every subsequent request was sent and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   replied it was not invoked at all. A callback written as `result.success` therefore threw a
   `TypeError` at the 2s mark before succeeding normally, and a callback relying on being told about
   failure never was. Callbacks now need to handle `undefined`, which is the shape of a failure.
-- **A failed request rejects with an `Error`**, where it previously rejected with a string. Anything
+- **The callback parameter is typed, so a callback that cannot handle a failure no longer compiles.**
+  `sendRequest`'s second parameter was `any`, which accepted `(result: IResult) => result.success` —
+  the shape that throws a `TypeError` the moment a request fails. It is now `RequestCallback`
+  (exported), whose response parameter admits `undefined`. This is the one change here that breaks a
+  build rather than a run, which is the point: the contract above is what changed, and a compile error
+  names every callback that no longer matches the expected signature, at the moment of upgrading,
+  instead of leaving each one to throw on a failure path that may be rare in testing and common in
+  use. A callback that already handled absence needs nothing; one that did not needs its parameter
+  widened to `(result?: IResult)`. Anything
   matching on the rejection value (`error.startsWith(...)`, `error === "..."`) needs updating, and
   `error.message` is where the text now lives — note that `String(error)` prefixes it with `Error: `.
   Some of the text changed too: a request that outlives its deadline now reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,12 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   requests are now refused at once. `init()` can be called again to retry, and it rejects with an
   `Error` like every other failure.
 
-  Only silence closes the connection. A handshake CODAP *answers* and declines leaves it open, since
-  CODAP is evidently there and listening; only the handshake fails. And a handshake closes only the
-  endpoint it created, so of two overlapping `init()` calls — which React's StrictMode produces from
-  a single effect — the one that fails cannot close the connection the other established.
+  Only silence closes the connection, and every other way the handshake can fail leaves it open,
+  because none of them says anything about whether CODAP is there: CODAP answering and declining,
+  CODAP answering with no value, and the handshake message failing to post all leave a usable
+  connection and fail only the handshake. And a handshake closes only the endpoint it created, so of
+  two overlapping `init()` calls — which React's StrictMode produces from a single effect — the one
+  that fails cannot close the connection the other established.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   `TypeError` at the 2s mark before succeeding normally, and a callback relying on being told about
   failure never was. Callbacks now need to handle `undefined`, which is the shape of a failure.
 - **A failed request rejects with an `Error`**, where it previously rejected with a string. Anything
-  matching on the rejection value (`error.startsWith(...)`, `error === "..."`) needs updating; the
-  message text is unchanged, so `String(error)` and `error.message` carry what the string did.
+  matching on the rejection value (`error.startsWith(...)`, `error === "..."`) needs updating, and
+  `error.message` is where the text now lives — note that `String(error)` prefixes it with `Error: `.
+  Some of the text changed too: a request that outlives its deadline now reports
+  `sendRequest: CODAP request exceeded 60000ms: …` rather than
+  `handleResponse: CODAP request timed out: …`, which is reserved for the handshake.
 - **`sendRequest` rejects on paths that previously never settled at all.** With no connection —
   before `initializePlugin()` or after `destroy()` — it used to return a promise that stayed pending
   forever, a silent no-op. It now rejects. Since the documented pattern of passing a callback and
@@ -48,6 +51,13 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   declared return type narrows from `Promise<unknown>` to `Promise<IResult>`, which is
   source-compatible for anyone casting the result.
 
+- **A failed `init()` handshake now closes the connection**, and its optional callback is invoked
+  with `undefined` rather than being skipped. Previously a handshake that drew no reply left a
+  connection object behind that nothing was listening to, so every subsequent request was sent and
+  then waited out the full deadline — a minute apiece for a plugin that had already been told it was
+  not running inside CODAP. Those requests are now refused at once. `init()` can be called again to
+  retry, and it rejects with an `Error` like every other failure.
+
 ### Changed
 
 - **A request now waits up to 60 seconds for a CODAP response, rather than about 2 seconds.**
@@ -66,10 +76,12 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
 ### Added
 
 - `codapInterface.getRequestTimeout()` and `codapInterface.setRequestTimeout(ms)`.
-- `stats.countDiReqDeadlineExceeded`, the number of requests that ran out of time. `getStats()`
-  previously reported no counter for them at all, while `countDiRplTimeout` counts iframe-phone's
-  advisory probe — which fires for every request slower than 2s and so is expected to be non-zero on
-  a plugin doing bulk work. Both are documented in the published type declarations.
+- `stats.countDiReqFailed`, the number of requests that failed, and `stats.countDiReqDeadlineExceeded`
+  for the subset that ran out of time. `getStats()` previously reported no counter for either, while
+  `countDiRplTimeout` counts iframe-phone's advisory probe — which fires for every request slower than
+  2s and so is expected to be non-zero on a plugin doing bulk work. `countDiRplFail` now means only
+  what its name says, a request CODAP answered and declined, rather than mixing those with failures.
+  Every counter is documented in the published type declarations.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   what its name says, a request CODAP answered and declined, rather than mixing those with failures.
   Every counter is documented in the published type declarations.
 
+  The counters also reconcile now: `countDiReq` minus the three outcome counters is the number of
+  requests still in flight. A batched request is answered with an array, which has no top-level
+  `success`, so it was counted as a decline however it went — meaning every successful `init()`
+  handshake reported one. It counts as the single request it was, successful only if every result in
+  it succeeded.
+
 ### Fixed
 
 - **Request failures inside the bundled helpers are reported rather than thrown.** `selectSelf`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,13 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   forever, a silent no-op. It now rejects. Since the documented pattern of passing a callback and
   discarding the promise leaves nothing attached to observe that, an unhandled rejection appears
   where nothing happened before. Attach a `.catch`, even when the callback is doing the real work.
-- **An exception thrown by `init()`'s `stateHandler` or callback no longer prevents it from
-  settling.** They were invoked before the handshake's promise was resolved, so a throw from one left
-  `initializePlugin()` pending forever with the exception discarded. They are now invoked after it
-  settles, and what they throw is reported the same way a request callback's exception is.
+- **An exception thrown while `init()` finishes no longer prevents it from settling.** Merging the
+  saved state CODAP returned, and then `stateHandler` and the callback, all ran before the handshake's
+  promise was resolved, so a throw from any of them left `initializePlugin()` pending forever with the
+  exception discarded. A saved state carrying a throwing getter was enough to do it. They now run
+  after it settles, and what they throw is reported the way a request callback's exception is. Note
+  that a merge which throws partway leaves the interactive state partly updated, so a plugin that
+  cares should treat the uncaught error as meaning `getInteractiveState()` may be incomplete.
 - **An exception thrown by a request callback is rethrown as an uncaught error** rather than being
   swallowed. The request has already settled by the time its callback runs, so a throw from it is a
   bug in the callback rather than a failure of the request — but it must not escape into the stack
@@ -79,12 +82,20 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   requests are now refused at once. `init()` can be called again to retry, and it rejects with an
   `Error` like every other failure.
 
+  **What counts as "nothing answers" is iframe-phone's own 2 second advisory window**, and that is
+  not proof CODAP is absent: a CODAP that is alive but slow to complete the underlying "hello"
+  exchange looks identical from here, and its connection will be closed where on `^0.1.9` it stayed
+  usable. Calling `init()` again re-establishes it. The trade is deliberate — the alternative is a
+  plugin loaded outside CODAP waiting a full minute per request to find out — and the handshake asks
+  CODAP for far less work than the requests this release exists to stop failing.
+
   Only silence closes the connection, and every other way the handshake can fail leaves it open,
   because none of them says anything about whether CODAP is there: CODAP answering and declining,
-  CODAP answering with no value, and the handshake message failing to post all leave a usable
-  connection and fail only the handshake. And a handshake closes only the endpoint it created, so of
-  two overlapping `init()` calls — which React's StrictMode produces from a single effect — the one
-  that fails cannot close the connection the other established.
+  CODAP answering with no value, and the handshake message failing to send all leave a usable
+  connection and fail only the handshake. Nor does silence close a connection CODAP has already been
+  seen answering — a reply to any other request, or a notification, outranks it — so an `init()` that
+  goes silent cannot close a connection an earlier one established, in either order. This matters for
+  two overlapping `init()` calls, which React's StrictMode produces from a single effect.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,11 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
 
   **What counts as "nothing answers" is iframe-phone's own 2 second advisory window**, and that is
   not proof CODAP is absent: a CODAP that is alive but slow to complete the underlying "hello"
-  exchange looks identical from here. The guess is not final, though. If that CODAP answers after
-  all, its reply reopens the connection and requests resume, so being slow costs a plugin the
-  handshake rather than the session; calling `init()` again also re-establishes it. The trade is
+  exchange looks identical from here. The guess is not final, though: if that CODAP answers after
+  all, its reply reopens the connection and requests resume. Note what the reopen does not recover —
+  `initializePlugin()` stays rejected and the saved state that late reply carried is not delivered,
+  so a plugin that restores state should call `init()` again rather than rely on it, or it will
+  answer CODAP's next request for its state with nothing and overwrite what was stored. The trade is
   deliberate — the alternative is a plugin loaded outside CODAP waiting a full minute per request to
   find out — and the handshake asks CODAP for far less work than the requests this release exists to
   stop failing.
@@ -144,7 +146,8 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
   `component[undefined]` when the frame comes back without an id. The other two reject with a
   descriptive message: a lookup that gets no answer says nothing about whether the name is free or
   the collection exists, and that is the caller's to decide.
-- A reply arriving after its request had already failed no longer marks the connection active or
-  counts a success against it.
+- A reply arriving after its request had already failed no longer counts a success against it, or
+  settles it a second time. It is still recorded as evidence that CODAP is there, which is what lets
+  it reopen a connection closed for silence.
 - `stats.timeDiFirstReq` was never set; each data-interactive request overwrote
   `stats.timeCodapFirstReq` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,10 +84,12 @@ only by moving to `^0.2.0` deliberately, rather than silently on their next inst
 
   **What counts as "nothing answers" is iframe-phone's own 2 second advisory window**, and that is
   not proof CODAP is absent: a CODAP that is alive but slow to complete the underlying "hello"
-  exchange looks identical from here, and its connection will be closed where on `^0.1.9` it stayed
-  usable. Calling `init()` again re-establishes it. The trade is deliberate — the alternative is a
-  plugin loaded outside CODAP waiting a full minute per request to find out — and the handshake asks
-  CODAP for far less work than the requests this release exists to stop failing.
+  exchange looks identical from here. The guess is not final, though. If that CODAP answers after
+  all, its reply reopens the connection and requests resume, so being slow costs a plugin the
+  handshake rather than the session; calling `init()` again also re-establishes it. The trade is
+  deliberate — the alternative is a plugin loaded outside CODAP waiting a full minute per request to
+  find out — and the handshake asks CODAP for far less work than the requests this release exists to
+  stop failing.
 
   Only silence closes the connection, and every other way the handshake can fail leaves it open,
   because none of them says anything about whether CODAP is there: CODAP answering and declining,

--- a/README.md
+++ b/README.md
@@ -46,8 +46,20 @@ codapInterface.setRequestTimeout(120000);  // allow longer for very large reques
 value they were given. A non-finite or non-positive value falls back to the default.
 
 `sendRequest` accepts an optional callback in addition to returning a promise. The callback
-receives CODAP's response, or `undefined` when CODAP did not respond at all — note that this is
-distinct from a response of `{ success: false }`, which means CODAP answered and declined.
+receives CODAP's response, or `undefined` when the request failed — note that this is distinct from
+a response of `{ success: false }`, which means CODAP answered and declined.
+
+`sendRequest` returns a promise whether or not a callback is passed, and that promise rejects on
+the same failures the callback reports as `undefined`: the request exceeded its deadline, or there
+was no connection to send it on. A request issued before `initializePlugin()` is called, or after
+`codapInterface.destroy()`, rejects rather than doing nothing. A rejected promise with nothing
+attached to it becomes an unhandled rejection, so handle the promise even when the callback is
+doing the real work:
+
+```js
+codapInterface.sendRequest(message, result => { /* ... */ })
+              .catch(error => console.warn("request failed", error));
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ codapInterface.sendRequest(message, result => { /* ... */ })
 ```
 
 The deadline applies to each request separately, so a helper that chains several can take a multiple
-of it. `createCollectionFromAttribute`, which issues up to three requests in sequence, is the
-practical case.
+of it. `createCollectionFromAttribute` is the case to know about: when it has to find an unused name
+for the new collection it searches for one suffix at a time, up to 104 requests in sequence, so its
+worst case is that multiple of the deadline. That worst case needs a document already holding a
+hundred similarly-named collections; the ordinary path is four requests.
 
 ### Exceptions thrown by your callback
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ value they were given. A non-finite or non-positive value falls back to the defa
 receives CODAP's response, or `undefined` when the request failed — note that this is distinct from
 a response of `{ success: false }`, which means CODAP answered and declined.
 
+In TypeScript the callback's parameter has to admit that absence. The exported `RequestCallback` type
+is `(response?: IResult, request?: any) => void`, so a callback declared to take `IResult` alone does
+not compile — it is the one that throws when a request fails:
+
+```ts
+codapInterface.sendRequest(message, (result?: IResult) => {
+  if (!result) { return; }        // the request failed; the promise rejects with the reason
+  if (result.success) { /* ... */ }
+});
+```
+
+A batched request — an array of requests — is answered with an array of results, which does not fit
+that type. Batch through the returned promise rather than a callback.
+
 `sendRequest` returns a promise whether or not a callback is passed, and that promise rejects with
 an `Error` on the same failures the callback reports as `undefined`: the request exceeded its
 deadline, CODAP answered with no value, or there was no connection to send it on. A request issued
@@ -74,10 +88,14 @@ rather than being logged and discarded. By the time the callback runs its reques
 settled, so what it throws is a bug in the callback and not a failure of the request — it does not
 reject the promise, and the request's outcome is unaffected.
 
-It stays loud on purpose. The most likely thing for a callback to throw is a `TypeError` from
-reading `result.success` on the `undefined` it receives when a request fails — a mistake worth
-finding, and one that logging would hide from `window.onerror` and from whatever error reporting a
-plugin relies on. If you pass callbacks that can throw, handle the error inside the callback.
+It stays loud on purpose. Logging it instead would hide a bug in your plugin from `window.onerror`
+and from whatever error reporting you rely on. If you pass callbacks that can throw, handle the error
+inside the callback.
+
+The classic version of this is reading `result.success` on the `undefined` a callback receives when a
+request fails. In TypeScript `RequestCallback` makes that a compile error instead, which is the whole
+reason the parameter is typed; in JavaScript it remains a `TypeError` at runtime, on whichever failure
+path reaches it first.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ const myComponent = () => {
 
 For more examples of how to use the npm package, see the [CODAP Plugin Starter Project](https://github.com/concord-consortium/codap-plugin-starter-project).
 
+### Request timeouts
+
+A request waits up to 60 seconds for CODAP to respond before it is rejected. Requests over large
+datasets can legitimately take many seconds — creating several thousand items, say — so the
+deadline is deliberately generous, and exists only so that a CODAP which never responds at all
+(page closed, iframe removed) cannot leave a caller waiting forever.
+
+```js
+codapInterface.getRequestTimeout();        // 60000
+codapInterface.setRequestTimeout(120000);  // allow longer for very large requests
+```
+
+`setRequestTimeout` applies to requests issued after the call; requests already in flight keep the
+value they were given. A non-finite or non-positive value falls back to the default.
+
+`sendRequest` accepts an optional callback in addition to returning a promise. The callback
+receives CODAP's response, or `undefined` when CODAP did not respond at all — note that this is
+distinct from a response of `{ success: false }`, which means CODAP answered and declined.
+
 ## Development
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -63,8 +63,17 @@ codapInterface.sendRequest(message, (result?: IResult) => {
 });
 ```
 
-A batched request — an array of requests — is answered with an array of results, which does not fit
-that type. Batch through the returned promise rather than a callback.
+CODAP answers a batched request — an array of requests — with an array of results, so its callback
+takes that array instead, as `BatchRequestCallback`. Which shape is required follows from the message:
+passing an array requires the array form, and passing a single request rejects it. A callback can
+therefore never be paired with a response it is unable to read.
+
+```ts
+codapInterface.sendRequest([firstRequest, secondRequest], (results?: IResult[]) => {
+  if (!results) { return; }       // the request failed; the promise rejects with the reason
+  results.forEach(result => { /* ... */ });
+});
+```
 
 `sendRequest` returns a promise whether or not a callback is passed, and that promise rejects with
 an `Error` on the same failures the callback reports as `undefined`: the request exceeded its

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ codapInterface.sendRequest([firstRequest, secondRequest], (results?: IResult[]) 
 
 `sendRequest` returns a promise whether or not a callback is passed, and that promise rejects with
 an `Error` on the same failures the callback reports as `undefined`: the request exceeded its
-deadline, CODAP answered with no value, or there was no connection to send it on. A request issued
+deadline, CODAP answered with no value, there was no connection to send it on, or the request could
+not be sent at all — an uncloneable value in the message, say. A request issued
 before `initializePlugin()` is called, or after `codapInterface.destroy()`, is refused rather than
 sent, and rejects at once. A rejected promise with nothing attached to it becomes an unhandled
 rejection, so handle the promise even when the callback is doing the real work:

--- a/README.md
+++ b/README.md
@@ -6,27 +6,30 @@ This npm library provides two main files that will aid in interfacing with the C
 
 ### Installing and usage
 
-In the directory of your plugin project, run `npm install codap-plugin-api`.
+In the directory of your plugin project, run
+`npm install @concord-consortium/codap-plugin-api`.
 
 In myComponent.js:
 
-```
-import codapInterface from "codap-plugin-api";
-import codapHelpers from "codap-plugin-api";
+```js
+import { initializePlugin } from "@concord-consortium/codap-plugin-api";
 
 const myComponent = () => {
   useEffect(() => {
-    const myOptions = {
-      pluginName: myPlugin;
-      version: 1.0.0;
+    initializePlugin({
+      pluginName: "myPlugin",
+      version: "1.0.0",
       dimensions: {
         width: 300,
         height: 400
-      };
-    codapHelpers.initializePlugin(myOptions);
+      }
+    }).catch(error => console.warn("could not connect to CODAP", error));
   }, []);
-}
+};
 ```
+
+Everything the package exports is a named export, including `codapInterface` for the lower-level
+request API.
 
 For more examples of how to use the npm package, see the [CODAP Plugin Starter Project](https://github.com/concord-consortium/codap-plugin-starter-project).
 
@@ -101,7 +104,11 @@ path reaches it first.
 
 ### Building
 
-If you want to build a local version run `npm build`, it will create the files in the `dist` folder.
+To build a local version, run `npm run build`. `tsc` compiles the sources into `build/`, then rollup
+bundles them into the package's entry points at the repository root: `codap-plugin-api.js` and the
+type declarations in `codap-plugin-api.d.ts`. The bundle is generated at build time and git-ignored;
+the declarations are committed, so a change affecting the public API needs a build and the regenerated
+`codap-plugin-api.d.ts` committed with it, rather than hand-edited.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,32 @@ request API.
 
 For more examples of how to use the npm package, see the [CODAP Plugin Starter Project](https://github.com/concord-consortium/codap-plugin-starter-project).
 
+### Connecting to CODAP
+
+`initializePlugin()` performs a handshake with CODAP and resolves with whatever state CODAP had saved
+for your plugin. If nothing answers that handshake within about two seconds, it rejects and the
+connection is marked closed, so requests issued afterwards are refused immediately rather than each
+waiting out the request timeout below.
+
+Two seconds is not proof CODAP is absent. A CODAP that is alive but slow to finish the underlying
+handshake looks the same from here, so treat a rejection as "not connected yet" rather than "not
+running inside CODAP":
+
+```js
+initializePlugin(options)
+  .catch(error => console.warn("could not connect to CODAP", error));
+```
+
+If that CODAP does answer afterwards, the connection reopens by itself and requests resume — but the
+promise above stays rejected, and the saved state that late answer carried is **not** delivered. So a
+plugin that restores saved state should call `initializePlugin()` again rather than rely on the
+reopen; otherwise it will answer CODAP's next request for its state with nothing, overwriting what
+was stored. `codapInterface.getConnectionState()` reports `"preinit"`, `"active"` or `"closed"`, and
+is the only way to observe either the close or the reopen.
+
+`codapInterface.destroy()` closes the connection deliberately, and that one does not reopen;
+`initializePlugin()` can be called again to reconnect.
+
 ### Request timeouts
 
 A request waits up to 60 seconds for CODAP to respond before it is rejected. Requests over large

--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ codapInterface.setRequestTimeout(120000);  // allow longer for very large reques
 `setRequestTimeout` applies to requests issued after the call; requests already in flight keep the
 value they were given. A non-finite or non-positive value falls back to the default.
 
-`sendRequest` accepts an optional callback in addition to returning a promise. The callback
-receives CODAP's response, or `undefined` when the request failed — note that this is distinct from
-a response of `{ success: false }`, which means CODAP answered and declined.
+`sendRequest` accepts an optional callback in addition to returning a promise. The callback receives
+CODAP's response, or `undefined` when the request failed — note that this is distinct from a response
+of `{ success: false }`, which means CODAP answered and declined.
+
+It is invoked exactly once, synchronously as the promise settles. That is *before* any `.then` or
+`await` continuation on the same request, since those are microtasks: if you use both, the callback
+runs first.
 
 In TypeScript the callback's parameter has to admit that absence. The exported `RequestCallback` type
 is `(response?: IResult, request?: any) => void`, so a callback declared to take `IResult` alone does

--- a/README.md
+++ b/README.md
@@ -49,17 +49,33 @@ value they were given. A non-finite or non-positive value falls back to the defa
 receives CODAP's response, or `undefined` when the request failed — note that this is distinct from
 a response of `{ success: false }`, which means CODAP answered and declined.
 
-`sendRequest` returns a promise whether or not a callback is passed, and that promise rejects on
-the same failures the callback reports as `undefined`: the request exceeded its deadline, or there
-was no connection to send it on. A request issued before `initializePlugin()` is called, or after
-`codapInterface.destroy()`, rejects rather than doing nothing. A rejected promise with nothing
-attached to it becomes an unhandled rejection, so handle the promise even when the callback is
-doing the real work:
+`sendRequest` returns a promise whether or not a callback is passed, and that promise rejects with
+an `Error` on the same failures the callback reports as `undefined`: the request exceeded its
+deadline, CODAP answered with no value, or there was no connection to send it on. A request issued
+before `initializePlugin()` is called, or after `codapInterface.destroy()`, is refused rather than
+sent, and rejects at once. A rejected promise with nothing attached to it becomes an unhandled
+rejection, so handle the promise even when the callback is doing the real work:
 
 ```js
 codapInterface.sendRequest(message, result => { /* ... */ })
               .catch(error => console.warn("request failed", error));
 ```
+
+The deadline applies to each request separately, so a helper that chains several can take a multiple
+of it. `createCollectionFromAttribute`, which issues up to three requests in sequence, is the
+practical case.
+
+### Exceptions thrown by your callback
+
+If the callback you pass to `sendRequest` throws, the exception is rethrown as an uncaught error
+rather than being logged and discarded. By the time the callback runs its request has already
+settled, so what it throws is a bug in the callback and not a failure of the request — it does not
+reject the promise, and the request's outcome is unaffected.
+
+It stays loud on purpose. The most likely thing for a callback to throw is a `TypeError` from
+reading `result.success` on the `undefined` it receives when a request fails — a mistake worth
+finding, and one that logging would hide from `window.onerror` and from whatever error reporting a
+plugin relies on. If you pass callbacks that can throw, handle the error inside the callback.
 
 ## Development
 

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -112,11 +112,14 @@ type ClientHandler = (notification: ClientNotification) => void;
  * satisfy it, and will not compile — which is the intent, because such a callback throws a
  * `TypeError` the first time a request fails, on a path a plugin may not exercise until it is in
  * front of users.
- *
- * A batched request — an array of requests — is answered with an array of results. That does not fit
- * here, so batch through the returned promise rather than a callback.
  */
 type RequestCallback = (response?: IResult, request?: any) => void;
+/**
+ * As `RequestCallback`, for a batched request: CODAP answers an array of requests with an array of
+ * results. `sendRequest` requires this shape when the message is an array and rejects it otherwise,
+ * so a callback cannot be paired with a response it is unable to read.
+ */
+type BatchRequestCallback = (response?: IResult[], request?: any) => void;
 declare const codapInterface: {
     /**
      * Connection statistics
@@ -288,7 +291,7 @@ declare const codapInterface: {
      *
      * @return {Promise} The promise of the response from CODAP.
      */
-    sendRequest(message: any, callback?: RequestCallback): Promise<unknown>;
+    sendRequest<TMessage>(message: TMessage, callback?: (TMessage extends readonly any[] ? BatchRequestCallback : RequestCallback) | undefined): Promise<unknown>;
     /**
      * Registers a handler to respond to CODAP-initiated requests and
      * notifications. See {@link https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-API#codap-initiated-actions}
@@ -312,4 +315,4 @@ declare const codapInterface: {
     parseResourceSelector(iResource: string): any;
 };
 
-export { type ClientHandler, type ClientNotification, type IConfig, type IDimensions, type IInitializePlugin, type IResult, type RequestCallback, addCasesToSelection, addComponentListener, addDataContextChangeListener, addDataContextsListListener, codapInterface, createChildCase, createChildCollection, createCollectionFromAttribute, createDataContext, createDataContextFromURL, createItems, createNewAttribute, createNewCollection, createParentCollection, createSingleOrParentCase, createTable, ensureUniqueCollectionName, getAllItems, getAttribute, getAttributeList, getCaseByFormulaSearch, getCaseByID, getCaseByIndex, getCaseBySearch, getCaseCount, getCollection, getCollectionList, getDataContext, getItemByCaseID, getItemByID, getItemByIndex, getItemBySearch, getItemCount, getListOfDataContexts, getSelectionList, initializePlugin, selectCases, selectSelf, sendMessage, updateAttribute, updateAttributePosition, updateCaseById, updateCases, updateItemByCaseID, updateItemByID, updateItemByIndex };
+export { type BatchRequestCallback, type ClientHandler, type ClientNotification, type IConfig, type IDimensions, type IInitializePlugin, type IResult, type RequestCallback, addCasesToSelection, addComponentListener, addDataContextChangeListener, addDataContextsListListener, codapInterface, createChildCase, createChildCollection, createCollectionFromAttribute, createDataContext, createDataContextFromURL, createItems, createNewAttribute, createNewCollection, createParentCollection, createSingleOrParentCase, createTable, ensureUniqueCollectionName, getAllItems, getAttribute, getAttributeList, getCaseByFormulaSearch, getCaseByID, getCaseByIndex, getCaseBySearch, getCaseCount, getCollection, getCollectionList, getDataContext, getItemByCaseID, getItemByID, getItemByIndex, getItemBySearch, getItemCount, getListOfDataContexts, getSelectionList, initializePlugin, selectCases, selectSelf, sendMessage, updateAttribute, updateAttributePosition, updateCaseById, updateCases, updateItemByCaseID, updateItemByID, updateItemByIndex };

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -29,9 +29,24 @@ declare const codapInterface: {
      * Connection statistics
      */
     stats: {
+        /** How many requests were sent to CODAP. */
         countDiReq: number;
+        /** How many requests CODAP answered with `{success: true}`. */
         countDiRplSuccess: number;
+        /**
+         * How many requests CODAP answered with `{success: false}` — that is, answered and declined.
+         * These are outcomes, not failures: the request's promise resolves with the response. For
+         * requests that failed, see `countDiReqFailed`.
+         */
         countDiRplFail: number;
+        /**
+         * How many requests failed, and so rejected: no connection to send on, no answer within the
+         * deadline, an answer carrying no result, or the send itself throwing.
+         *
+         * `countDiReq - countDiRplSuccess - countDiRplFail - countDiReqFailed` is the number still in
+         * flight. `countDiReqDeadlineExceeded` counts the subset that ran out of time.
+         */
+        countDiReqFailed: number;
         /**
          * How many times iframe-phone's advisory 2s timer has reported that no reply has arrived yet.
          *
@@ -40,7 +55,10 @@ declare const codapInterface: {
          * wrong. For requests that actually ran out of time, see `countDiReqDeadlineExceeded`.
          */
         countDiRplTimeout: number;
-        /** How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. */
+        /**
+         * How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. A subset
+         * of `countDiReqFailed`.
+         */
         countDiReqDeadlineExceeded: number;
         countCodapReq: number;
         countCodapUnhandledReq: number;
@@ -91,9 +109,24 @@ declare const codapInterface: {
      */
     setRequestTimeout(timeout: number): void;
     getStats(): {
+        /** How many requests were sent to CODAP. */
         countDiReq: number;
+        /** How many requests CODAP answered with `{success: true}`. */
         countDiRplSuccess: number;
+        /**
+         * How many requests CODAP answered with `{success: false}` — that is, answered and declined.
+         * These are outcomes, not failures: the request's promise resolves with the response. For
+         * requests that failed, see `countDiReqFailed`.
+         */
         countDiRplFail: number;
+        /**
+         * How many requests failed, and so rejected: no connection to send on, no answer within the
+         * deadline, an answer carrying no result, or the send itself throwing.
+         *
+         * `countDiReq - countDiRplSuccess - countDiRplFail - countDiReqFailed` is the number still in
+         * flight. `countDiReqDeadlineExceeded` counts the subset that ran out of time.
+         */
+        countDiReqFailed: number;
         /**
          * How many times iframe-phone's advisory 2s timer has reported that no reply has arrived yet.
          *
@@ -102,7 +135,10 @@ declare const codapInterface: {
          * wrong. For requests that actually ran out of time, see `countDiReqDeadlineExceeded`.
          */
         countDiRplTimeout: number;
-        /** How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. */
+        /**
+         * How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. A subset
+         * of `countDiReqFailed`.
+         */
         countDiReqDeadlineExceeded: number;
         countCodapReq: number;
         countCodapUnhandledReq: number;

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -67,6 +67,10 @@ declare const codapInterface: {
      * needs to fail fast. See `requestTimeout` for why this is not iframe-phone's 2s timer.
      */
     getRequestTimeout(): number;
+    /**
+     * A non-finite or non-positive value falls back to the default: setTimeout treats NaN and
+     * negative delays as 0, which would silently make every subsequent request fail at once.
+     */
     setRequestTimeout(timeout: number): void;
     getStats(): {
         countDiReq: number;

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -179,10 +179,26 @@ declare const codapInterface: {
      * Update interactive frame to set name and dimensions and other configuration
      * information.
      *
+     * Resolves with the interactive state CODAP had saved for this plugin, or rejects with an `Error`
+     * if the handshake does not succeed. The callback is invoked either way, as `sendRequest`'s is:
+     * with the saved state on success, and with `undefined` on failure.
+     *
+     * **When nothing answers the handshake the connection is closed**, so requests issued afterwards
+     * are refused at once rather than each waiting out `getRequestTimeout()`. The trigger is
+     * iframe-phone's own 2 second advisory window, which is not proof that CODAP is absent: a CODAP
+     * that is alive but slow to complete the underlying "hello" exchange looks the same from here, and
+     * its connection will be closed. Call `init()` again to retry — it re-establishes the connection.
+     *
+     * Any other failure leaves the connection usable and fails only the handshake, since none of them
+     * says anything about whether CODAP is there: CODAP answering and declining, CODAP answering with
+     * no value, and the request failing to send are all in this group. So is a handshake that goes
+     * silent after CODAP has already answered something else.
+     *
      * @param iConfig {object} Configuration. Optional properties: title {string},
      *                        version {string}, dimensions {object}
      *
-     * @param iCallback {function(interactiveState)}
+     * @param iCallback {function(interactiveState)} Optional. Receives the saved state, or `undefined`
+     *                        if the handshake failed.
      * @return {Promise} Promise of interactiveState;
      */
     init(iConfig: IConfig, iCallback?: ((arg0: any) => void) | undefined): Promise<any>;

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -177,8 +177,9 @@ declare const codapInterface: {
      *   includes `{success: false}`, which means CODAP answered and declined — a resolved promise, not
      *   a rejected one.
      * - **The request failed:** the promise rejects with an `Error` and the callback is invoked with
-     *   `undefined`. This covers exceeding the deadline, there being no connection to send on (before
-     *   `initializePlugin()` or after `destroy()`), and CODAP answering with no value at all.
+     *   `undefined`. Every way a request can fail reports this way — exceeding the deadline, there
+     *   being no connection to send on (before `initializePlugin()` or after `destroy()`), CODAP
+     *   answering with no value at all, and the send itself throwing.
      *
      * The callback is invoked exactly once, after the promise has settled. A callback written as
      * `result.success` therefore has to handle the `undefined` it receives on failure. Note that the

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -184,11 +184,12 @@ declare const codapInterface: {
      * if the handshake does not succeed. The callback is invoked either way, as `sendRequest`'s is:
      * with the saved state on success, and with `undefined` on failure.
      *
-     * **When nothing answers the handshake the connection is closed**, so requests issued afterwards
-     * are refused at once rather than each waiting out `getRequestTimeout()`. The trigger is
+     * **When nothing answers the handshake the connection is marked closed**, so requests issued
+     * afterwards are refused at once rather than each waiting out `getRequestTimeout()`. The trigger is
      * iframe-phone's own 2 second advisory window, which is not proof that CODAP is absent: a CODAP
-     * that is alive but slow to complete the underlying "hello" exchange looks the same from here, and
-     * its connection will be closed. Call `init()` again to retry — it re-establishes the connection.
+     * that is alive but slow to complete the underlying "hello" exchange looks the same from here.
+     * That guess is not final, though — if CODAP answers after all, the connection reopens by itself
+     * and requests resume. Calling `init()` again also re-establishes it.
      *
      * Any other failure leaves the connection usable and fails only the handshake, since none of them
      * says anything about whether CODAP is there: CODAP answering and declining, CODAP answering with

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -144,7 +144,8 @@ declare const codapInterface: {
         countDiRplFail: number;
         /**
          * How many requests failed, and so rejected: no connection to send on, no answer within the
-         * deadline, an answer carrying no result, or the send itself throwing.
+         * deadline, an answer carrying no result, the send itself throwing, or — for `init()`'s handshake
+         * alone — nothing answering within iframe-phone's advisory window.
          *
          * `countDiReq - countDiRplSuccess - countDiRplFail - countDiReqFailed` is the number still in
          * flight. `countDiReqDeadlineExceeded` counts the subset that ran out of time.
@@ -247,7 +248,8 @@ declare const codapInterface: {
         countDiRplFail: number;
         /**
          * How many requests failed, and so rejected: no connection to send on, no answer within the
-         * deadline, an answer carrying no result, or the send itself throwing.
+         * deadline, an answer carrying no result, the send itself throwing, or — for `init()`'s handshake
+         * alone — nothing answering within iframe-phone's advisory window.
          *
          * `countDiReq - countDiRplSuccess - countDiRplFail - countDiReqFailed` is the number still in
          * flight. `countDiReqDeadlineExceeded` counts the subset that ran out of time.

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -125,7 +125,14 @@ declare const codapInterface: {
      * Connection statistics
      */
     stats: {
-        /** How many requests were sent to CODAP. */
+        /**
+         * How many requests the caller issued.
+         *
+         * Counted when `sendRequest` is called, not when the request reaches CODAP, so a request refused
+         * before it could be sent — no connection, or a closed one — is included. That is what makes the
+         * arithmetic on `countDiReqFailed` below hold; counting only the ones that got as far as CODAP
+         * left the refusals incrementing a failure count against a total that had not moved.
+         */
         countDiReq: number;
         /** How many requests CODAP answered with `{success: true}`. */
         countDiRplSuccess: number;
@@ -205,7 +212,14 @@ declare const codapInterface: {
      */
     setRequestTimeout(timeout: number): void;
     getStats(): {
-        /** How many requests were sent to CODAP. */
+        /**
+         * How many requests the caller issued.
+         *
+         * Counted when `sendRequest` is called, not when the request reaches CODAP, so a request refused
+         * before it could be sent — no connection, or a closed one — is included. That is what makes the
+         * arithmetic on `countDiReqFailed` below hold; counting only the ones that got as far as CODAP
+         * left the refusals incrementing a failure count against a total that had not moved.
+         */
         countDiReq: number;
         /** How many requests CODAP answered with `{success: true}`. */
         countDiRplSuccess: number;

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -32,7 +32,16 @@ declare const codapInterface: {
         countDiReq: number;
         countDiRplSuccess: number;
         countDiRplFail: number;
+        /**
+         * How many times iframe-phone's advisory 2s timer has reported that no reply has arrived yet.
+         *
+         * This counts probes, not failures. A request slower than 2s that goes on to succeed normally
+         * increments it, so on a plugin doing bulk work a high count is expected and says nothing is
+         * wrong. For requests that actually ran out of time, see `countDiReqDeadlineExceeded`.
+         */
         countDiRplTimeout: number;
+        /** How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. */
+        countDiReqDeadlineExceeded: number;
         countCodapReq: number;
         countCodapUnhandledReq: number;
         countCodapRplSuccess: number;
@@ -85,7 +94,16 @@ declare const codapInterface: {
         countDiReq: number;
         countDiRplSuccess: number;
         countDiRplFail: number;
+        /**
+         * How many times iframe-phone's advisory 2s timer has reported that no reply has arrived yet.
+         *
+         * This counts probes, not failures. A request slower than 2s that goes on to succeed normally
+         * increments it, so on a plugin doing bulk work a high count is expected and says nothing is
+         * wrong. For requests that actually ran out of time, see `countDiReqDeadlineExceeded`.
+         */
         countDiRplTimeout: number;
+        /** How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. */
+        countDiReqDeadlineExceeded: number;
         countCodapReq: number;
         countCodapUnhandledReq: number;
         countCodapRplSuccess: number;
@@ -107,15 +125,34 @@ declare const codapInterface: {
      * @param iInteractiveState {Object}
      */
     updateInteractiveState(iInteractiveState: any): void;
+    /**
+     * Tears down the connection to CODAP. Requests issued afterwards are refused rather than sent;
+     * `init()` can be called again to reconnect.
+     */
     destroy(): void;
     /**
      * Sends a request to CODAP. The format of the message is as defined in
      * {@link https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-API}.
      *
-     * @param message {String}
-     * @param callback {function(response, request)} Optional callback to handle
-     *    the CODAP response. Note both the response and the initial request will
-     *    sent.
+     * A request waits up to `getRequestTimeout()` milliseconds (60 seconds by default) for CODAP to
+     * answer. It settles exactly once, and both the promise and the callback report every outcome:
+     *
+     * - **CODAP answered:** the promise resolves with the response and the callback receives it. That
+     *   includes `{success: false}`, which means CODAP answered and declined — a resolved promise, not
+     *   a rejected one.
+     * - **The request failed:** the promise rejects with an `Error` and the callback is invoked with
+     *   `undefined`. This covers exceeding the deadline, there being no connection to send on (before
+     *   `initializePlugin()` or after `destroy()`), and CODAP answering with no value at all.
+     *
+     * The callback is invoked exactly once, after the promise has settled. A callback written as
+     * `result.success` therefore has to handle the `undefined` it receives on failure. Note that the
+     * promise rejects whether or not a callback is passed, so it still needs a `.catch` to avoid an
+     * unhandled rejection. An exception thrown by the callback itself is rethrown as an uncaught error
+     * rather than failing the request, which has already settled by then.
+     *
+     * @param message {Object} The request, as in the Data Interactive API.
+     * @param callback {function(response, request)} Optional. Receives the response, or `undefined`
+     *    if the request failed, followed by the original request.
      *
      * @return {Promise} The promise of the response from CODAP.
      */

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -189,7 +189,12 @@ declare const codapInterface: {
      * iframe-phone's own 2 second advisory window, which is not proof that CODAP is absent: a CODAP
      * that is alive but slow to complete the underlying "hello" exchange looks the same from here.
      * That guess is not final, though — if CODAP answers after all, the connection reopens by itself
-     * and requests resume. Calling `init()` again also re-establishes it.
+     * and requests resume.
+     *
+     * The reopen recovers the connection, not the handshake: this promise stays rejected, and the saved
+     * state that late reply carried is **not** delivered, so `getInteractiveState()` is still empty. A
+     * plugin that restores state should call `init()` again rather than rely on the reopen — otherwise
+     * it will answer CODAP's next request for its state with nothing, overwriting what was stored.
      *
      * Any other failure leaves the connection usable and fails only the handshake, since none of them
      * says anything about whether CODAP is there: CODAP answering and declining, CODAP answering with
@@ -205,8 +210,17 @@ declare const codapInterface: {
      */
     init(iConfig: IConfig, iCallback?: ((arg0: any) => void) | undefined): Promise<any>;
     /**
-     * Current known state of the connection
-     * @param {'preinit' || 'init' || 'active' || 'inactive' || 'closed'}
+     * Current known state of the connection. One of three values:
+     *
+     * - `"preinit"` — no handshake has completed yet, either before the first `init()` or during one.
+     * - `"active"` — CODAP has been heard from: it answered a request, or sent a notification.
+     * - `"closed"` — requests are refused without being sent. Two causes, which behave differently:
+     *   `destroy()`, which is final until `init()` is called again; and a handshake that nothing
+     *   answered, which reverts to `"active"` by itself if CODAP answers after all.
+     *
+     * This is the only way to observe either of those, since neither raises an event.
+     *
+     * @returns {'preinit' | 'active' | 'closed'}
      */
     getConnectionState(): string;
     /**

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -61,6 +61,13 @@ declare const codapInterface: {
      * @param {'preinit' || 'init' || 'active' || 'inactive' || 'closed'}
      */
     getConnectionState(): string;
+    /**
+     * How long, in milliseconds, to wait for a CODAP response before rejecting a request.
+     * Raise this for plugins that issue requests over very large datasets; lower it if a caller
+     * needs to fail fast. See `requestTimeout` for why this is not iframe-phone's 2s timer.
+     */
+    getRequestTimeout(): number;
+    setRequestTimeout(timeout: number): void;
     getStats(): {
         countDiReq: number;
         countDiRplSuccess: number;

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -277,8 +277,9 @@ declare const codapInterface: {
      *   being no connection to send on (before `initializePlugin()` or after `destroy()`), CODAP
      *   answering with no value at all, and the send itself throwing.
      *
-     * The callback is invoked exactly once, after the promise has settled. A callback written as
-     * `result.success` therefore has to handle the `undefined` it receives on failure. Note that the
+     * The callback is invoked exactly once, synchronously after the promise is resolved or rejected —
+     * that is, before any `.then` or `await` continuation runs, since those are microtasks. A callback
+     * written as `result.success` therefore has to handle the `undefined` it receives on failure. Note that the
      * promise rejects whether or not a callback is passed, so it still needs a `.catch` to avoid an
      * unhandled rejection. An exception thrown by the callback itself is rethrown as an uncaught error
      * rather than failing the request, which has already settled by then.

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -62,14 +62,23 @@ declare const codapInterface: {
      */
     getConnectionState(): string;
     /**
-     * How long, in milliseconds, to wait for a CODAP response before rejecting a request.
-     * Raise this for plugins that issue requests over very large datasets; lower it if a caller
-     * needs to fail fast. See `requestTimeout` for why this is not iframe-phone's 2s timer.
+     * How long, in milliseconds, a request waits for a CODAP response before it is rejected.
+     * Defaults to 60000. Raise it for plugins that issue requests over very large datasets; lower it
+     * if a caller needs to fail fast.
+     *
+     * This is deliberately much longer than the 2s timer inside iframe-phone, which reports that no
+     * reply has arrived yet without cancelling the request — a large request routinely takes longer
+     * than that and still succeeds.
      */
     getRequestTimeout(): number;
     /**
-     * A non-finite or non-positive value falls back to the default: setTimeout treats NaN and
-     * negative delays as 0, which would silently make every subsequent request fail at once.
+     * Sets how long, in milliseconds, a request waits for a CODAP response before it is rejected.
+     * Applies to requests issued after the call; requests already in flight keep the value they
+     * were given.
+     *
+     * A non-finite or non-positive value falls back to the default of 60000, and larger values are
+     * clamped: setTimeout treats NaN and negative delays as 0 and overflows above its 32-bit
+     * ceiling, either of which would silently make every subsequent request fail at once.
      */
     setRequestTimeout(timeout: number): void;
     getStats(): {

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -1,3 +1,84 @@
+interface Attribute {
+    name: string;
+    formula?: string;
+    description?: string;
+    type?: string;
+    cid?: string;
+    precision?: string;
+    unit?: string;
+    editable?: boolean;
+    renameable?: boolean;
+    deleteable?: boolean;
+    hidden?: boolean;
+}
+interface CodapItemValues {
+    [attr: string]: any;
+}
+interface CodapItem {
+    id: number | string;
+    values: CodapItemValues;
+}
+type Action = "create" | "get" | "update" | "delete";
+
+interface IDimensions {
+    width: number;
+    height: number;
+}
+interface IInitializePlugin {
+    pluginName: string;
+    version: string;
+    dimensions: IDimensions;
+}
+interface IResult {
+    success: boolean;
+    values: any;
+}
+declare const sendMessage: (action: Action, resource: string, values?: CodapItemValues) => Promise<IResult>;
+declare const initializePlugin: (options: IInitializePlugin) => Promise<any>;
+declare const createTable: (dataContext: string, datasetName?: string) => Promise<IResult>;
+declare const selectSelf: () => void;
+declare const addComponentListener: (callback: ClientHandler) => void;
+declare const getListOfDataContexts: () => Promise<IResult>;
+declare const getDataContext: (dataContextName: string) => Promise<IResult>;
+declare const createDataContext: (dataContextName: string) => Promise<IResult>;
+declare const createDataContextFromURL: (url: string) => Promise<IResult>;
+declare const addDataContextsListListener: (callback: ClientHandler) => void;
+declare const addDataContextChangeListener: (dataContextName: string, callback: ClientHandler) => void;
+declare const getCollectionList: (dataContextName: string) => Promise<IResult>;
+declare const getCollection: (dataContextName: string, collectionName: string) => Promise<IResult>;
+declare const createParentCollection: (dataContextName: string, collectionName: string, attrs?: Attribute[]) => Promise<IResult>;
+declare const createChildCollection: (dataContextName: string, collectionName: string, parentCollectionName: string, attrs?: Attribute[]) => Promise<IResult>;
+declare const createNewCollection: (dataContextName: string, collectionName: string, attrs?: Attribute[]) => Promise<IResult>;
+declare const ensureUniqueCollectionName: (dataContextName: string, collectionName: string, index: number) => Promise<string | undefined>;
+declare const getAttribute: (dataContextName: string, collectionName: string, attributeName: string) => Promise<IResult>;
+declare const getAttributeList: (dataContextName: string, collectionName: string) => Promise<IResult>;
+declare const createNewAttribute: (dataContextName: string, collectionName: string, attributeName: string) => Promise<IResult>;
+declare const updateAttribute: (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => Promise<IResult>;
+declare const updateAttributePosition: (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => Promise<IResult>;
+declare const createCollectionFromAttribute: (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number | string) => Promise<IResult>;
+declare const getCaseCount: (dataContextName: string, collectionName: string) => Promise<IResult>;
+declare const getCaseByIndex: (dataContextName: string, collectionName: string, index: number) => Promise<IResult>;
+declare const getCaseByID: (dataContextName: string, caseID: number | string) => Promise<IResult>;
+declare const getCaseBySearch: (dataContextName: string, collectionName: string, search: string) => Promise<IResult>;
+declare const getCaseByFormulaSearch: (dataContextName: string, collectionName: string, search: string) => Promise<IResult>;
+declare const createSingleOrParentCase: (dataContextName: string, collectionName: string, values: Array<CodapItemValues>) => Promise<IResult>;
+declare const createChildCase: (dataContextName: string, collectionName: string, parentCaseID: number | string, values: CodapItemValues) => Promise<IResult>;
+declare const updateCaseById: (dataContextName: string, caseID: number | string, values: CodapItemValues) => Promise<IResult>;
+declare const updateCases: (dataContextName: string, collectionName: string, values: CodapItem[]) => Promise<IResult>;
+declare const getSelectionList: (dataContextName: string) => Promise<IResult>;
+declare const selectCases: (dataContextName: string, caseIds: Array<string | number>) => Promise<IResult>;
+declare const addCasesToSelection: (dataContextName: string, caseIds: Array<string | number>) => Promise<IResult>;
+declare const getItemCount: (dataContextName: string) => Promise<IResult>;
+declare const getAllItems: (dataContextName: string) => Promise<IResult>;
+declare const getItemByID: (dataContextName: string, itemID: number | string) => Promise<IResult>;
+declare const getItemByIndex: (dataContextName: string, index: number) => Promise<IResult>;
+declare const getItemByCaseID: (dataContextName: string, caseID: number | string) => Promise<IResult>;
+declare const getItemBySearch: (dataContextName: string, search: string) => Promise<IResult>;
+declare const createItems: (dataContextName: string, items: Array<CodapItemValues>) => Promise<IResult>;
+declare const updateItemByID: (dataContextName: string, itemID: number | string, values: CodapItemValues) => Promise<IResult>;
+declare const updateItemByIndex: (dataContextName: string, index: number, values: CodapItemValues) => Promise<IResult>;
+declare const updateItemByCaseID: (dataContextName: string, caseID: number | string, values: CodapItemValues) => Promise<IResult>;
+
 interface IConfig {
     stateHandler?: (arg0: any) => void;
     customInteractiveStateHandler?: boolean;
@@ -24,6 +105,18 @@ interface ClientNotification {
     values: any;
 }
 type ClientHandler = (notification: ClientNotification) => void;
+/**
+ * What `sendRequest` passes a callback: CODAP's response, or `undefined` if the request failed.
+ *
+ * The `undefined` is the point of the type. A callback declared to take `IResult` alone does not
+ * satisfy it, and will not compile — which is the intent, because such a callback throws a
+ * `TypeError` the first time a request fails, on a path a plugin may not exercise until it is in
+ * front of users.
+ *
+ * A batched request — an array of requests — is answered with an array of results. That does not fit
+ * here, so batch through the returned promise rather than a callback.
+ */
+type RequestCallback = (response?: IResult, request?: any) => void;
 declare const codapInterface: {
     /**
      * Connection statistics
@@ -188,12 +281,14 @@ declare const codapInterface: {
      * rather than failing the request, which has already settled by then.
      *
      * @param message {Object} The request, as in the Data Interactive API.
-     * @param callback {function(response, request)} Optional. Receives the response, or `undefined`
-     *    if the request failed, followed by the original request.
+     * @param callback {RequestCallback} Optional. Receives the response, or `undefined` if the request
+     *    failed, followed by the original request. Its parameter has to admit `undefined`: a callback
+     *    typed for the response alone does not compile, because it is the one that throws when a
+     *    request fails.
      *
      * @return {Promise} The promise of the response from CODAP.
      */
-    sendRequest(message: any, callback?: any): Promise<unknown>;
+    sendRequest(message: any, callback?: RequestCallback): Promise<unknown>;
     /**
      * Registers a handler to respond to CODAP-initiated requests and
      * notifications. See {@link https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-API#codap-initiated-actions}
@@ -217,85 +312,4 @@ declare const codapInterface: {
     parseResourceSelector(iResource: string): any;
 };
 
-interface Attribute {
-    name: string;
-    formula?: string;
-    description?: string;
-    type?: string;
-    cid?: string;
-    precision?: string;
-    unit?: string;
-    editable?: boolean;
-    renameable?: boolean;
-    deleteable?: boolean;
-    hidden?: boolean;
-}
-interface CodapItemValues {
-    [attr: string]: any;
-}
-interface CodapItem {
-    id: number | string;
-    values: CodapItemValues;
-}
-type Action = "create" | "get" | "update" | "delete";
-
-interface IDimensions {
-    width: number;
-    height: number;
-}
-interface IInitializePlugin {
-    pluginName: string;
-    version: string;
-    dimensions: IDimensions;
-}
-interface IResult {
-    success: boolean;
-    values: any;
-}
-declare const sendMessage: (action: Action, resource: string, values?: CodapItemValues) => Promise<IResult>;
-declare const initializePlugin: (options: IInitializePlugin) => Promise<any>;
-declare const createTable: (dataContext: string, datasetName?: string) => Promise<IResult>;
-declare const selectSelf: () => void;
-declare const addComponentListener: (callback: ClientHandler) => void;
-declare const getListOfDataContexts: () => Promise<IResult>;
-declare const getDataContext: (dataContextName: string) => Promise<IResult>;
-declare const createDataContext: (dataContextName: string) => Promise<IResult>;
-declare const createDataContextFromURL: (url: string) => Promise<IResult>;
-declare const addDataContextsListListener: (callback: ClientHandler) => void;
-declare const addDataContextChangeListener: (dataContextName: string, callback: ClientHandler) => void;
-declare const getCollectionList: (dataContextName: string) => Promise<IResult>;
-declare const getCollection: (dataContextName: string, collectionName: string) => Promise<IResult>;
-declare const createParentCollection: (dataContextName: string, collectionName: string, attrs?: Attribute[]) => Promise<IResult>;
-declare const createChildCollection: (dataContextName: string, collectionName: string, parentCollectionName: string, attrs?: Attribute[]) => Promise<IResult>;
-declare const createNewCollection: (dataContextName: string, collectionName: string, attrs?: Attribute[]) => Promise<IResult>;
-declare const ensureUniqueCollectionName: (dataContextName: string, collectionName: string, index: number) => Promise<string | undefined>;
-declare const getAttribute: (dataContextName: string, collectionName: string, attributeName: string) => Promise<IResult>;
-declare const getAttributeList: (dataContextName: string, collectionName: string) => Promise<IResult>;
-declare const createNewAttribute: (dataContextName: string, collectionName: string, attributeName: string) => Promise<IResult>;
-declare const updateAttribute: (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => Promise<IResult>;
-declare const updateAttributePosition: (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => Promise<IResult>;
-declare const createCollectionFromAttribute: (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number | string) => Promise<IResult>;
-declare const getCaseCount: (dataContextName: string, collectionName: string) => Promise<IResult>;
-declare const getCaseByIndex: (dataContextName: string, collectionName: string, index: number) => Promise<IResult>;
-declare const getCaseByID: (dataContextName: string, caseID: number | string) => Promise<IResult>;
-declare const getCaseBySearch: (dataContextName: string, collectionName: string, search: string) => Promise<IResult>;
-declare const getCaseByFormulaSearch: (dataContextName: string, collectionName: string, search: string) => Promise<IResult>;
-declare const createSingleOrParentCase: (dataContextName: string, collectionName: string, values: Array<CodapItemValues>) => Promise<IResult>;
-declare const createChildCase: (dataContextName: string, collectionName: string, parentCaseID: number | string, values: CodapItemValues) => Promise<IResult>;
-declare const updateCaseById: (dataContextName: string, caseID: number | string, values: CodapItemValues) => Promise<IResult>;
-declare const updateCases: (dataContextName: string, collectionName: string, values: CodapItem[]) => Promise<IResult>;
-declare const getSelectionList: (dataContextName: string) => Promise<IResult>;
-declare const selectCases: (dataContextName: string, caseIds: Array<string | number>) => Promise<IResult>;
-declare const addCasesToSelection: (dataContextName: string, caseIds: Array<string | number>) => Promise<IResult>;
-declare const getItemCount: (dataContextName: string) => Promise<IResult>;
-declare const getAllItems: (dataContextName: string) => Promise<IResult>;
-declare const getItemByID: (dataContextName: string, itemID: number | string) => Promise<IResult>;
-declare const getItemByIndex: (dataContextName: string, index: number) => Promise<IResult>;
-declare const getItemByCaseID: (dataContextName: string, caseID: number | string) => Promise<IResult>;
-declare const getItemBySearch: (dataContextName: string, search: string) => Promise<IResult>;
-declare const createItems: (dataContextName: string, items: Array<CodapItemValues>) => Promise<IResult>;
-declare const updateItemByID: (dataContextName: string, itemID: number | string, values: CodapItemValues) => Promise<IResult>;
-declare const updateItemByIndex: (dataContextName: string, index: number, values: CodapItemValues) => Promise<IResult>;
-declare const updateItemByCaseID: (dataContextName: string, caseID: number | string, values: CodapItemValues) => Promise<IResult>;
-
-export { type ClientHandler, type ClientNotification, type IConfig, type IDimensions, type IInitializePlugin, type IResult, addCasesToSelection, addComponentListener, addDataContextChangeListener, addDataContextsListListener, codapInterface, createChildCase, createChildCollection, createCollectionFromAttribute, createDataContext, createDataContextFromURL, createItems, createNewAttribute, createNewCollection, createParentCollection, createSingleOrParentCase, createTable, ensureUniqueCollectionName, getAllItems, getAttribute, getAttributeList, getCaseByFormulaSearch, getCaseByID, getCaseByIndex, getCaseBySearch, getCaseCount, getCollection, getCollectionList, getDataContext, getItemByCaseID, getItemByID, getItemByIndex, getItemBySearch, getItemCount, getListOfDataContexts, getSelectionList, initializePlugin, selectCases, selectSelf, sendMessage, updateAttribute, updateAttributePosition, updateCaseById, updateCases, updateItemByCaseID, updateItemByID, updateItemByIndex };
+export { type ClientHandler, type ClientNotification, type IConfig, type IDimensions, type IInitializePlugin, type IResult, type RequestCallback, addCasesToSelection, addComponentListener, addDataContextChangeListener, addDataContextsListListener, codapInterface, createChildCase, createChildCollection, createCollectionFromAttribute, createDataContext, createDataContextFromURL, createItems, createNewAttribute, createNewCollection, createParentCollection, createSingleOrParentCase, createTable, ensureUniqueCollectionName, getAllItems, getAttribute, getAttributeList, getCaseByFormulaSearch, getCaseByID, getCaseByIndex, getCaseBySearch, getCaseCount, getCollection, getCollectionList, getDataContext, getItemByCaseID, getItemByID, getItemByIndex, getItemBySearch, getItemCount, getListOfDataContexts, getSelectionList, initializePlugin, selectCases, selectSelf, sendMessage, updateAttribute, updateAttributePosition, updateCaseById, updateCases, updateItemByCaseID, updateItemByID, updateItemByIndex };

--- a/codap-plugin-api.d.ts
+++ b/codap-plugin-api.d.ts
@@ -200,7 +200,7 @@ declare const getAttributeList: (dataContextName: string, collectionName: string
 declare const createNewAttribute: (dataContextName: string, collectionName: string, attributeName: string) => Promise<IResult>;
 declare const updateAttribute: (dataContextName: string, collectionName: string, attributeName: string, attribute: Attribute, values: CodapItemValues) => Promise<IResult>;
 declare const updateAttributePosition: (dataContextName: string, collectionName: string, attrName: string, newPosition: number) => Promise<IResult>;
-declare const createCollectionFromAttribute: (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number | string) => Promise<unknown>;
+declare const createCollectionFromAttribute: (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number | string) => Promise<IResult>;
 declare const getCaseCount: (dataContextName: string, collectionName: string) => Promise<IResult>;
 declare const getCaseByIndex: (dataContextName: string, collectionName: string, index: number) => Promise<IResult>;
 declare const getCaseByID: (dataContextName: string, caseID: number | string) => Promise<IResult>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/codap-plugin-api",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/codap-plugin-api",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "fork-ts-checker-webpack-plugin": "^9.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/codap-plugin-api",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/codap-plugin-api",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "fork-ts-checker-webpack-plugin": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "testPathIgnorePatterns": [
+      "/build/",
       "/node_modules/"
     ],
     "coveragePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/codap-plugin-api",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "An API to ease the development of CODAP plugins",
   "keywords": [
     "CODAP",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "scripts": {
     "build": "run-s build:tsc build:rollup",
+    "prebuild:tsc": "node -e \"require('fs').rmSync('build', {recursive: true, force: true})\"",
     "build:tsc": "tsc",
     "build:rollup": "rollup --config",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/codap-plugin-api",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "An API to ease the development of CODAP plugins",
   "keywords": [
     "CODAP",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "testPathIgnorePatterns": [
-      "/build/",
       "/node_modules/"
     ],
     "coveragePathIgnorePatterns": [

--- a/src/api/codap-helper.spec.ts
+++ b/src/api/codap-helper.spec.ts
@@ -9,8 +9,8 @@ const mockSendRequest = codapInterface.sendRequest as jest.Mock;
 
 const attr = { name: "Height" };
 
-/** Lets queued promise callbacks run, so a fire-and-forget helper's reporting can be observed. */
-function flushMicrotasks() {
+/** Yields to the task queue, so a fire-and-forget helper's queued reporting has run. */
+function flushQueued() {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
 
@@ -160,7 +160,7 @@ describe("selectSelf", () => {
 
     selectSelf();
     answer({ success: true, values: { id: 42 } });
-    await flushMicrotasks();
+    await flushQueued();
 
     expect(requests()[1]).toEqual({
       action: "notify", resource: "component[42]", values: { request: "select" }
@@ -175,10 +175,10 @@ describe("selectSelf", () => {
 
     selectSelf();
     answer({ success: false });
-    await flushMicrotasks();
+    await flushQueued();
 
     expect(requests()).toHaveLength(1);          // nothing to select, so no second request
-    expect(warn).toHaveBeenCalledWith("selectSelf failed", "");
+    expect(warn).toHaveBeenCalledWith("selectSelf: CODAP declined the interactiveFrame lookup", "");
   });
 
   // Without an id the resource would read `component[undefined]`, asking CODAP to select something
@@ -188,10 +188,10 @@ describe("selectSelf", () => {
 
     selectSelf();
     answer({ success: true, values: {} });
-    await flushMicrotasks();
+    await flushQueued();
 
     expect(requests()).toHaveLength(1);
-    expect(warn).toHaveBeenCalledWith("selectSelf failed", "");
+    expect(warn).toHaveBeenCalledWith("selectSelf: the interactiveFrame reply carried no id", "");
   });
 
   // An unanswered request invokes the callback with undefined *and* rejects. Reporting from both
@@ -201,9 +201,9 @@ describe("selectSelf", () => {
 
     selectSelf();
     answer(undefined);
-    await flushMicrotasks();
+    await flushQueued();
 
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith("selectSelf failed", new Error("no connection"));
+    expect(warn).toHaveBeenCalledWith("selectSelf: the interactiveFrame lookup failed", new Error("no connection"));
   });
 });

--- a/src/api/codap-helper.spec.ts
+++ b/src/api/codap-helper.spec.ts
@@ -1,0 +1,96 @@
+import { createCollectionFromAttribute } from "./codap-helper";
+import { codapInterface } from "./codap-interface";
+
+jest.mock("./codap-interface", () => ({
+  codapInterface: { sendRequest: jest.fn() }
+}));
+
+const mockSendRequest = codapInterface.sendRequest as jest.Mock;
+
+const attr = { name: "Height" };
+
+/** The requests issued so far, in call order. */
+function requests() {
+  return mockSendRequest.mock.calls.map(call => call[0]);
+}
+
+// createCollectionFromAttribute walks three requests -- look up the collection, create it, move the
+// attribute into it -- and each step decides what the next one does. These answer them by action so
+// a test can fail one step without restating the others.
+function respond(answers: { get?: any, create?: any, update?: any }) {
+  mockSendRequest.mockImplementation((message: any) => {
+    const answer = answers[message.action as keyof typeof answers];
+    return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer);
+  });
+}
+
+describe("createCollectionFromAttribute", () => {
+  beforeEach(() => {
+    mockSendRequest.mockReset();
+  });
+
+  // The caller asked for the attribute to end up in its own collection; the move is the step that
+  // makes that true, so its result is the one the caller needs.
+  it("resolves with the result of moving the attribute", async () => {
+    respond({
+      get: { success: false },                       // no collection by that name yet
+      create: { success: true, values: { id: 7 } },
+      update: { success: true, values: { moved: true } }
+    });
+
+    await expect(createCollectionFromAttribute("ctx", "Cases", attr, "root"))
+      .resolves.toEqual({ success: true, values: { moved: true } });
+
+    expect(requests().map(r => r.action)).toEqual(["get", "create", "update"]);
+    expect(requests()[1].values).toEqual({ name: "Height", title: "Height", parent: "_root_" });
+  });
+
+  // Before this contract the promise resolved on the lookup reply, so a caller was told a
+  // reorganization that never happened had succeeded.
+  it("resolves with CODAP's refusal when the collection cannot be created", async () => {
+    respond({
+      get: { success: false },
+      create: { success: false, values: { error: "name in use" } }
+    });
+
+    await expect(createCollectionFromAttribute("ctx", "Cases", attr, "root"))
+      .resolves.toEqual({ success: false, values: { error: "name in use" } });
+
+    // with no collection to move it to, the attribute must be left where it is
+    expect(requests().map(r => r.action)).toEqual(["get", "create"]);
+  });
+
+  it("rejects when a request goes unanswered", async () => {
+    respond({ get: new Error("sendRequest: CODAP request exceeded 60000ms") });
+
+    await expect(createCollectionFromAttribute("ctx", "Cases", attr, "root"))
+      .rejects.toThrow(/exceeded/);
+  });
+
+  // A lookup that succeeds without an attribute list used to throw a TypeError reading
+  // `values.attrs.length` out of an async callback, where nothing could observe it.
+  it("treats a successful lookup with no attribute list as a collection to leave alone", async () => {
+    respond({
+      get: { success: true, values: {} },
+      create: { success: true },
+      update: { success: true }
+    });
+
+    await expect(createCollectionFromAttribute("ctx", "Cases", attr, "root"))
+      .resolves.toEqual({ success: true });
+  });
+
+  // The lookups ensureUniqueCollectionName issues all report the name taken, so it runs out of
+  // candidates. Nothing was refused by CODAP, but the caller still needs a failure it can read.
+  it("reports a failure when no unused collection name is available", async () => {
+    // `attr.name === oldCollectionName` takes the rename branch without needing an attribute list
+    respond({ get: { success: true, values: { attrs: [attr] } } });
+
+    const result = await createCollectionFromAttribute("ctx", "Height", attr, "root");
+
+    expect(result.success).toBe(false);
+    expect(result.values.error).toMatch(/no unused collection name/);
+    // it gave up rather than creating a collection under a name it hadn't checked
+    expect(requests().some(r => r.action === "create")).toBe(false);
+  });
+});

--- a/src/api/codap-helper.spec.ts
+++ b/src/api/codap-helper.spec.ts
@@ -1,4 +1,4 @@
-import { createCollectionFromAttribute } from "./codap-helper";
+import { createCollectionFromAttribute, selectSelf } from "./codap-helper";
 import { codapInterface } from "./codap-interface";
 
 jest.mock("./codap-interface", () => ({
@@ -9,6 +9,11 @@ const mockSendRequest = codapInterface.sendRequest as jest.Mock;
 
 const attr = { name: "Height" };
 
+/** Lets queued promise callbacks run, so a fire-and-forget helper's reporting can be observed. */
+function flushMicrotasks() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
 /** The requests issued so far, in call order. */
 function requests() {
   return mockSendRequest.mock.calls.map(call => call[0]);
@@ -17,9 +22,17 @@ function requests() {
 // createCollectionFromAttribute walks three requests -- look up the collection, create it, move the
 // attribute into it -- and each step decides what the next one does. These answer them by action so
 // a test can fail one step without restating the others.
+//
+// An action with no stubbed answer rejects rather than resolving `undefined`: sendRequest never
+// resolves with nothing, so a mock that did would let a test pass against a shape production cannot
+// produce. Rejecting also makes an unstubbed step visible instead of silently falling through.
 function respond(answers: { get?: any, create?: any, update?: any }) {
   mockSendRequest.mockImplementation((message: any) => {
-    const answer = answers[message.action as keyof typeof answers];
+    const action = message.action as keyof typeof answers;
+    if (!(action in answers)) {
+      return Promise.reject(new Error(`no stubbed answer for "${action}"`));
+    }
+    const answer = answers[action];
     return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer);
   });
 }
@@ -67,9 +80,11 @@ describe("createCollectionFromAttribute", () => {
       .rejects.toThrow(/exceeded/);
   });
 
-  // A lookup that succeeds without an attribute list used to throw a TypeError reading
-  // `values.attrs.length` out of an async callback, where nothing could observe it.
-  it("treats a successful lookup with no attribute list as a collection to leave alone", async () => {
+  // Reading `values.attrs.length` on a lookup that succeeded without an attribute list threw a
+  // TypeError, and it threw inside an async callback where nothing could observe it. Absent `attrs`
+  // is not evidence of a single-attribute collection, so the name-search branch is not taken and the
+  // attribute's own name is used.
+  it("does not read a missing attribute list as a single-attribute collection", async () => {
     respond({
       get: { success: true, values: {} },
       create: { success: true },
@@ -78,6 +93,10 @@ describe("createCollectionFromAttribute", () => {
 
     await expect(createCollectionFromAttribute("ctx", "Cases", attr, "root"))
       .resolves.toEqual({ success: true });
+    // one lookup only: no search for a unique name, and the collection takes the attribute's name
+    expect(requests().filter(r => r.action === "get")).toHaveLength(1);
+    expect(requests().find(r => r.action === "create")?.values)
+      .toEqual({ name: "Height", title: "Height", parent: "_root_" });
   });
 
   // The candidate range is part of the behaviour, not an implementation detail: an off-by-one in the
@@ -115,5 +134,76 @@ describe("createCollectionFromAttribute", () => {
     expect(result.values.error).toMatch(/no unused collection name/);
     // it gave up rather than creating a collection under a name it hadn't checked
     expect(requests().some(r => r.action === "create")).toBe(false);
+  });
+});
+
+// selectSelf is fire-and-forget: it discards both promises, so its callbacks are the only place an
+// outcome can be reported, and a rejection with nothing attached would surface as an unhandled
+// rejection. Both requests therefore carry a callback and a .catch.
+describe("selectSelf", () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockSendRequest.mockReset();
+    warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => warn.mockRestore());
+
+  /** Invokes the callback each request was given, as codapInterface does on a reply. */
+  function answer(...replies: any[]) {
+    mockSendRequest.mock.calls.forEach((call, i) => call[1]?.(replies[i]));
+  }
+
+  it("selects the component the frame reports", async () => {
+    mockSendRequest.mockResolvedValue(undefined);
+
+    selectSelf();
+    answer({ success: true, values: { id: 42 } });
+    await flushMicrotasks();
+
+    expect(requests()[1]).toEqual({
+      action: "notify", resource: "component[42]", values: { request: "select" }
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // The frame lookup reported only absence, so a CODAP answer of {success: false} left selectSelf
+  // doing nothing and saying nothing.
+  it("reports a frame lookup CODAP declined", async () => {
+    mockSendRequest.mockResolvedValue(undefined);
+
+    selectSelf();
+    answer({ success: false });
+    await flushMicrotasks();
+
+    expect(requests()).toHaveLength(1);          // nothing to select, so no second request
+    expect(warn).toHaveBeenCalledWith("selectSelf failed", "");
+  });
+
+  // Without an id the resource would read `component[undefined]`, asking CODAP to select something
+  // that cannot exist.
+  it("does not select a component when the frame has no id", async () => {
+    mockSendRequest.mockResolvedValue(undefined);
+
+    selectSelf();
+    answer({ success: true, values: {} });
+    await flushMicrotasks();
+
+    expect(requests()).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith("selectSelf failed", "");
+  });
+
+  // An unanswered request invokes the callback with undefined *and* rejects. Reporting from both
+  // would log one failure twice, so absence is left to the .catch.
+  it("reports an unanswered request once", async () => {
+    mockSendRequest.mockRejectedValue(new Error("no connection"));
+
+    selectSelf();
+    answer(undefined);
+    await flushMicrotasks();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith("selectSelf failed", new Error("no connection"));
   });
 });

--- a/src/api/codap-helper.spec.ts
+++ b/src/api/codap-helper.spec.ts
@@ -80,6 +80,29 @@ describe("createCollectionFromAttribute", () => {
       .resolves.toEqual({ success: true });
   });
 
+  // The candidate range is part of the behaviour, not an implementation detail: an off-by-one in the
+  // runaway-loop guard makes the helper report no name available while one still is. The suffix
+  // range is `Height` (no suffix) through `Height100`, so the last candidate has to be tried.
+  it("tries every candidate name through the hundredth suffix", async () => {
+    let asked = 0;
+    mockSendRequest.mockImplementation((message: any) => {
+      if (message.action !== "get") { return Promise.resolve({ success: true }); }
+      asked++;
+      // every name is taken except the last candidate
+      const taken = message.resource !== "dataContext[ctx].collection[Height100]";
+      return Promise.resolve({ success: taken });
+    });
+
+    // attr.name === oldCollectionName takes the branch that searches for a unique name
+    const result = await createCollectionFromAttribute("ctx", "Height", attr, "root");
+
+    expect(result.success).toBe(true);
+    // 1 existence check for the attribute's own collection, then Height, Height1 ... Height100
+    expect(asked).toBe(1 + 101);
+    expect(requests().find(r => r.action === "create")?.values)
+      .toEqual({ name: "Height100", title: "Height100", parent: "_root_" });
+  });
+
   // The lookups ensureUniqueCollectionName issues all report the name taken, so it runs out of
   // candidates. Nothing was refused by CODAP, but the caller still needs a failure it can read.
   it("reports a failure when no unused collection name is available", async () => {

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -84,7 +84,8 @@ export const selectSelf = () => {
       resource:  `component[${id}]`,
       values: {request: "select"}
     }, (result?: IResult) => {
-      if (!result?.success) {
+      // an undefined result means CODAP didn't respond, which the catch below reports
+      if (result && !result.success) {
         reportRequestFailure("selectSelf");
       }
     }).catch(error => reportRequestFailure("selectSelf", error));

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -195,9 +195,10 @@ export const createNewCollection = (dataContextName: string, collectionName: str
 
 export const ensureUniqueCollectionName = async (dataContextName: string, collectionName: string, index: number): Promise<string | undefined> => {
   index = index || 0;
-  // guard against runaway loops. Checked before the lookup rather than after, so giving up costs no
-  // request: each one can take up to the full request timeout, and this recurses once per attempt.
-  if (index >= 100) {
+  // guard against runaway loops. `> 100` rather than `>= 100` so that the hundredth suffix is still
+  // tried: the candidates are `collectionName` through `collectionName100`, and stopping at 99 would
+  // report no name available while one still was.
+  if (index > 100) {
     return undefined;
   }
   const uniqueName = `${collectionName}${index !== 0 ? index : ""}`;
@@ -254,16 +255,21 @@ export const updateAttributePosition = (dataContextName: string, collectionName:
 
 // Reorganizes the attribute into its own collection. Each step depends on the answer to the one
 // before it, so this follows the promise-form guidance above: it awaits every request and resolves
-// with the result of the last step it got to. A request that goes unanswered rejects; a step CODAP
-// explicitly refuses resolves with that refusal, so the caller always learns whether the attribute
-// ended up where it asked for.
+// with the result of the last step it reached — the attribute move when every step ran, or the step
+// CODAP refused. A request that goes unanswered rejects.
+//
+// Note what the resolved result does and does not tell the caller: that the steps this function
+// issued succeeded. It does not report what CODAP did in response, in particular whether the old
+// collection was removed once its last attribute left.
 export const createCollectionFromAttribute = async (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number|string): Promise<IResult> => {
   // check if a collection for the attribute already exists
   const getCollectionMessage = createMessage("get", `${ctxStr(dataContextName)}.${collStr(attr.name)}`);
   const existingCollection = await codapInterface.sendRequest(getCollectionMessage) as unknown as IResult;
 
-  // since you can't "re-parent" collections we need to create a temp top level collection, move the attribute,
-  // and then check if CODAP deleted the old collection as it became empty and if so rename the new collection
+  // Since you can't "re-parent" collections, the attribute gets a new collection of its own and is
+  // moved into it. When the attribute is the only one left in its old collection, or is the one the
+  // collection is named for, that new collection takes a name derived from the attribute's — and
+  // CODAP removes the old collection once it is empty.
   // (a successful lookup for a collection with no attribute list leaves `attrs` undefined, hence `?.`)
   const moveCollection = existingCollection.success &&
     (existingCollection.values?.attrs?.length === 1 || attr.name === oldCollectionName);

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -243,48 +243,54 @@ export const updateAttributePosition = (dataContextName: string, collectionName:
   });
 };
 
-export const createCollectionFromAttribute = (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number|string) => {
+// Reorganizes the attribute into its own collection. Each step depends on the answer to the one
+// before it, so this follows the promise-form guidance above: it awaits every request and resolves
+// with the result of the last step it got to. A request that goes unanswered rejects; a step CODAP
+// explicitly refuses resolves with that refusal, so the caller always learns whether the attribute
+// ended up where it asked for.
+export const createCollectionFromAttribute = async (dataContextName: string, oldCollectionName: string, attr: Attribute, parent: number|string): Promise<IResult> => {
   // check if a collection for the attribute already exists
   const getCollectionMessage = createMessage("get", `${ctxStr(dataContextName)}.${collStr(attr.name)}`);
+  const existingCollection = await codapInterface.sendRequest(getCollectionMessage) as unknown as IResult;
 
-  // Grandfathered exception to the promise-form guidance above: this reads the answer, so it would
-  // be better on promises, but its nested callbacks would need restructuring to convert. Until then
-  // it handles absence explicitly at each step.
-  return codapInterface.sendRequest(getCollectionMessage, async (result?: IResult) => {
-    if (!result) {
-      // nothing is known about the existing collection, so don't act on a guess
-      reportRequestFailure("createCollectionFromAttribute");
-      return;
-    }
-    // since you can't "re-parent" collections we need to create a temp top level collection, move the attribute,
-    // and then check if CODAP deleted the old collection as it became empty and if so rename the new collection
-    const moveCollection = result.success && (result.values.attrs.length === 1 || attr.name === oldCollectionName);
-    const newCollectionName = moveCollection
-      ? await ensureUniqueCollectionName(dataContextName, attr.name, 0)
-          .catch(error => { reportRequestFailure("createCollectionFromAttribute", error); return undefined; })
-      : attr.name;
-    if (newCollectionName === undefined) {
-      return;
-    }
-    const _parent = parent === "root" ? "_root_" : parent;
-    const createCollectionRequest = createMessage("create", `${ctxStr(dataContextName)}.collection`, {
-      "name": newCollectionName,
-      "title": newCollectionName,
-      parent: _parent,
-    });
+  // since you can't "re-parent" collections we need to create a temp top level collection, move the attribute,
+  // and then check if CODAP deleted the old collection as it became empty and if so rename the new collection
+  // (a successful lookup for a collection with no attribute list leaves `attrs` undefined, hence `?.`)
+  const moveCollection = existingCollection.success &&
+    (existingCollection.values?.attrs?.length === 1 || attr.name === oldCollectionName);
+  const newCollectionName = moveCollection
+    ? await ensureUniqueCollectionName(dataContextName, attr.name, 0)
+    : attr.name;
+  if (newCollectionName === undefined) {
+    // no unused name was available, so there is nothing to create the collection under. Nothing was
+    // asked of CODAP and nothing went wrong with the connection, so this is a refusal rather than a
+    // rejection: report it in the shape CODAP uses for a request it declines, and let the caller
+    // read `success` the same way it does for every other step.
+    return {
+      success: false,
+      values: { error: `createCollectionFromAttribute: no unused collection name based on "${attr.name}"` }
+    };
+  }
 
-    return codapInterface.sendRequest(createCollectionRequest, (createCollResult?: IResult) => {
-      if (createCollResult?.success) {
-        const moveAttributeRequest = createMessage("update", `${ctxStr(dataContextName)}.${collStr(oldCollectionName)}.attributeLocation[${attr.name}]`, {
-          "collection": newCollectionName,
-          "position": 0
-        });
-        // issued from a callback, so nothing is attached to observe a rejection
-        return codapInterface.sendRequest(moveAttributeRequest)
-                .catch(error => reportRequestFailure("createCollectionFromAttribute", error));
-      }
-    });
+  const _parent = parent === "root" ? "_root_" : parent;
+  const createCollectionRequest = createMessage("create", `${ctxStr(dataContextName)}.collection`, {
+    "name": newCollectionName,
+    "title": newCollectionName,
+    parent: _parent,
   });
+  const createCollectionResult = await codapInterface.sendRequest(createCollectionRequest) as unknown as IResult;
+  if (!createCollectionResult.success) {
+    // without the new collection there is nowhere to move the attribute to
+    return createCollectionResult;
+  }
+
+  const moveAttributeRequest = createMessage("update", `${ctxStr(dataContextName)}.${collStr(oldCollectionName)}.attributeLocation[${attr.name}]`, {
+    "collection": newCollectionName,
+    "position": 0
+  });
+  // moving the attribute is what makes the new collection the attribute's collection, so this is the
+  // result that answers whether the reorganization happened
+  return await codapInterface.sendRequest(moveAttributeRequest) as unknown as IResult;
 };
 
 ////////////// case functions //////////////

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -39,8 +39,9 @@ export const sendMessage = async (action: Action, resource: string, values?: Cod
 //
 // Prefer the promise form (`sendMessage`, or `await codapInterface.sendRequest(...)`) in helpers
 // that consume the answer: absence then arrives as a rejection, which is noisy if unhandled,
-// whereas an unchecked `undefined` yields a plausible-looking wrong answer. The callback form is
-// fine for fire-and-forget requests that nothing depends on.
+// whereas an unchecked `undefined` yields a plausible-looking wrong answer. The callback form suits
+// a fire-and-forget request that nothing depends on — but the promise still rejects on failure
+// whether or not anyone is reading it, so such a call needs a `.catch` as well as its callback.
 
 // Some helpers issue a request without awaiting it, so a rejection has nothing attached to observe
 // it. Report it rather than letting it surface as an unhandled rejection.

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -33,6 +33,22 @@ export const sendMessage = async (action: Action, resource: string, values?: Cod
   return await codapInterface.sendRequest(message) as unknown as IResult;
 };
 
+// CODAP answers a request with success true or false; it may also not answer at all, in which case
+// a callback receives `undefined`. Absence of a response is not a failure response — it licenses no
+// conclusion about what CODAP did — so each call site has to decide what not knowing means for it.
+//
+// Prefer the promise form (`sendMessage`, or `await codapInterface.sendRequest(...)`) in helpers
+// that consume the answer: absence then arrives as a rejection, which is noisy if unhandled,
+// whereas an unchecked `undefined` yields a plausible-looking wrong answer. The callback form is
+// fine for fire-and-forget requests that nothing depends on.
+
+// Some helpers issue a request without awaiting it, so a rejection has nothing attached to observe
+// it. Report it rather than letting it surface as an unhandled rejection.
+const reportRequestFailure = (context: string, error?: unknown) => {
+  // eslint-disable-next-line no-console
+  console.warn(`${context} failed`, error ?? "");
+};
+
 ////////////// public API //////////////
 
 export const initializePlugin = async (options: IInitializePlugin) => {
@@ -61,24 +77,24 @@ export const createTable = async (dataContext: string, datasetName?: string) => 
 // Selects this component. In CODAP this will bring this component to the front.
 export const selectSelf = () => {
 
+  // Neither request is awaited. A failed request reports an undefined result to its callback.
   const selectComponent = async function (id: number) {
     return codapInterface.sendRequest({
       action: "notify",
       resource:  `component[${id}]`,
       values: {request: "select"}
-    }, (result: IResult) => {
-      if (!result.success) {
-        // eslint-disable-next-line no-console
-        console.log("selectSelf failed");
+    }, (result?: IResult) => {
+      if (!result?.success) {
+        reportRequestFailure("selectSelf");
       }
-    });
+    }).catch(error => reportRequestFailure("selectSelf", error));
   };
 
-  codapInterface.sendRequest({action: "get", resource: "interactiveFrame"}, (result: IResult) => {
-    if (result.success) {
+  codapInterface.sendRequest({action: "get", resource: "interactiveFrame"}, (result?: IResult) => {
+    if (result?.success) {
       return selectComponent(result.values.id);
     }
-  });
+  }).catch(error => reportRequestFailure("selectSelf", error));
 };
 
 export const addComponentListener = (callback: ClientHandler) => {
@@ -176,11 +192,10 @@ export const ensureUniqueCollectionName = async (dataContextName: string, collec
     "resource": `${ctxStr(dataContextName)}.collection[${uniqueName}]`
   };
 
-  const result: IResult = await new Promise((resolve) => {
-    codapInterface.sendRequest(getCollMessage, (res: IResult) => {
-      resolve(res);
-    });
-  });
+  // sendRequest rejects when CODAP doesn't respond, so awaiting it throws here. Not hearing back
+  // says nothing about whether the collection exists, so let that reach the caller rather than
+  // concluding the name is free and risking a duplicate.
+  const result = await codapInterface.sendRequest(getCollMessage) as unknown as IResult;
 
   if (result.success) {
     // guard against runaway loops
@@ -231,11 +246,22 @@ export const createCollectionFromAttribute = (dataContextName: string, oldCollec
   // check if a collection for the attribute already exists
   const getCollectionMessage = createMessage("get", `${ctxStr(dataContextName)}.${collStr(attr.name)}`);
 
-  return codapInterface.sendRequest(getCollectionMessage, async (result: IResult) => {
+  // Grandfathered exception to the promise-form guidance above: this reads the answer, so it would
+  // be better on promises, but its nested callbacks would need restructuring to convert. Until then
+  // it handles absence explicitly at each step.
+  return codapInterface.sendRequest(getCollectionMessage, async (result?: IResult) => {
+    if (!result) {
+      // nothing is known about the existing collection, so don't act on a guess
+      reportRequestFailure("createCollectionFromAttribute");
+      return;
+    }
     // since you can't "re-parent" collections we need to create a temp top level collection, move the attribute,
     // and then check if CODAP deleted the old collection as it became empty and if so rename the new collection
     const moveCollection = result.success && (result.values.attrs.length === 1 || attr.name === oldCollectionName);
-    const newCollectionName = moveCollection ? await ensureUniqueCollectionName(dataContextName, attr.name, 0) : attr.name;
+    const newCollectionName = moveCollection
+      ? await ensureUniqueCollectionName(dataContextName, attr.name, 0)
+          .catch(error => { reportRequestFailure("createCollectionFromAttribute", error); return undefined; })
+      : attr.name;
     if (newCollectionName === undefined) {
       return;
     }
@@ -246,13 +272,15 @@ export const createCollectionFromAttribute = (dataContextName: string, oldCollec
       parent: _parent,
     });
 
-    return codapInterface.sendRequest(createCollectionRequest, (createCollResult: IResult) => {
-      if (createCollResult.success) {
+    return codapInterface.sendRequest(createCollectionRequest, (createCollResult?: IResult) => {
+      if (createCollResult?.success) {
         const moveAttributeRequest = createMessage("update", `${ctxStr(dataContextName)}.${collStr(oldCollectionName)}.attributeLocation[${attr.name}]`, {
           "collection": newCollectionName,
           "position": 0
         });
-        return codapInterface.sendRequest(moveAttributeRequest);
+        // issued from a callback, so nothing is attached to observe a rejection
+        return codapInterface.sendRequest(moveAttributeRequest)
+                .catch(error => reportRequestFailure("createCollectionFromAttribute", error));
       }
     });
   });

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -92,9 +92,17 @@ export const selectSelf = () => {
   };
 
   codapInterface.sendRequest({action: "get", resource: "interactiveFrame"}, (result?: IResult) => {
-    if (result?.success) {
-      return selectComponent(result.values.id);
+    // an undefined result means CODAP didn't respond, which the catch below reports
+    if (!result) {
+      return;
     }
+    // without the frame's id there is no component to select, and requesting `component[undefined]`
+    // would ask CODAP to select something that cannot exist
+    if (!result.success || result.values?.id === undefined) {
+      reportRequestFailure("selectSelf");
+      return;
+    }
+    return selectComponent(result.values.id);
   }).catch(error => reportRequestFailure("selectSelf", error));
 };
 
@@ -187,6 +195,11 @@ export const createNewCollection = (dataContextName: string, collectionName: str
 
 export const ensureUniqueCollectionName = async (dataContextName: string, collectionName: string, index: number): Promise<string | undefined> => {
   index = index || 0;
+  // guard against runaway loops. Checked before the lookup rather than after, so giving up costs no
+  // request: each one can take up to the full request timeout, and this recurses once per attempt.
+  if (index >= 100) {
+    return undefined;
+  }
   const uniqueName = `${collectionName}${index !== 0 ? index : ""}`;
   const getCollMessage = {
     "action": "get",
@@ -199,10 +212,6 @@ export const ensureUniqueCollectionName = async (dataContextName: string, collec
   const result = await codapInterface.sendRequest(getCollMessage) as unknown as IResult;
 
   if (result.success) {
-    // guard against runaway loops
-    if (index >= 100) {
-      return undefined;
-    }
     return ensureUniqueCollectionName(dataContextName, collectionName, index + 1);
   } else {
     return uniqueName;

--- a/src/api/codap-helper.ts
+++ b/src/api/codap-helper.ts
@@ -45,9 +45,13 @@ export const sendMessage = async (action: Action, resource: string, values?: Cod
 
 // Some helpers issue a request without awaiting it, so a rejection has nothing attached to observe
 // it. Report it rather than letting it surface as an unhandled rejection.
-const reportRequestFailure = (context: string, error?: unknown) => {
+//
+// `what` describes the specific thing that went wrong, not just the helper it went wrong in: for a
+// fire-and-forget helper this warning is the only diagnostic a plugin author gets, and one that
+// cannot say which of several outcomes occurred sends them reading source to find out.
+const reportRequestFailure = (what: string, error?: unknown) => {
   // eslint-disable-next-line no-console
-  console.warn(`${context} failed`, error ?? "");
+  console.warn(what, error ?? "");
 };
 
 ////////////// public API //////////////
@@ -87,9 +91,9 @@ export const selectSelf = () => {
     }, (result?: IResult) => {
       // an undefined result means CODAP didn't respond, which the catch below reports
       if (result && !result.success) {
-        reportRequestFailure("selectSelf");
+        reportRequestFailure("selectSelf: CODAP declined to select the component");
       }
-    }).catch(error => reportRequestFailure("selectSelf", error));
+    }).catch(error => reportRequestFailure("selectSelf: the select request failed", error));
   };
 
   codapInterface.sendRequest({action: "get", resource: "interactiveFrame"}, (result?: IResult) => {
@@ -99,12 +103,16 @@ export const selectSelf = () => {
     }
     // without the frame's id there is no component to select, and requesting `component[undefined]`
     // would ask CODAP to select something that cannot exist
-    if (!result.success || result.values?.id === undefined) {
-      reportRequestFailure("selectSelf");
+    if (!result.success) {
+      reportRequestFailure("selectSelf: CODAP declined the interactiveFrame lookup");
+      return;
+    }
+    if (result.values?.id === undefined) {
+      reportRequestFailure("selectSelf: the interactiveFrame reply carried no id");
       return;
     }
     return selectComponent(result.values.id);
-  }).catch(error => reportRequestFailure("selectSelf", error));
+  }).catch(error => reportRequestFailure("selectSelf: the interactiveFrame lookup failed", error));
 };
 
 export const addComponentListener = (callback: ClientHandler) => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -131,25 +131,6 @@ describe("the callback type", () => {
   });
 });
 
-describe("codapInterface.sendRequest", () => {
-  beforeEach(async () => {
-    jest.useRealTimers();
-    await initInterface();
-  });
-
-  it("resolves with the real response when it arrives after the advisory timeout", async () => {
-    const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
-    const callback = lastCallback();
-
-    advisoryTimeout(callback);        // the request is still in flight
-    await flush();
-    callback({ success: true, values: { itemIDs: ["a", "b"] } });   // CODAP finally replies
-
-    await expect(request).resolves.toEqual({ success: true, values: { itemIDs: ["a", "b"] } });
-  });
-
-});
-
 describe("codapInterface.sendRequest hard timeout", () => {
   beforeEach(async () => {
     jest.useRealTimers();
@@ -274,6 +255,9 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     expect(codapInterface.getStats().countDiRplFail).toBe(before.countDiRplFail);
   });
 
+  // The probe comes first, as it does in life: iframe-phone reports no reply at 2s, the request
+  // stays in flight, and only the deadline ends it. Both events reaching one request is the
+  // sequence this deadline handling exists to get right.
   it("the deadline passes: rejects, and says so in the stats", async () => {
     jest.useRealTimers();
     await initInterface();
@@ -283,6 +267,11 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     jest.useFakeTimers();
     const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
                                                callerCallback);
+    // settling is synchronous, so if the probe were treated as an outcome the callback would
+    // already have fired by the next line
+    advisoryTimeout(lastCallback());
+    expect(callerCallback).not.toHaveBeenCalled();
+
     const rejection = expect(request).rejects.toThrow(/exceeded/);
     jest.advanceTimersByTime(kDefaultTimeout);
     await rejection;
@@ -349,6 +338,29 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     await rejection;
 
     expectSettledOnce(callerCallback, undefined);
+  });
+
+  // The requests likeliest to reach a failure message are the largest -- the deadline exists for a
+  // createItems carrying thousands of items -- so the message quotes only the head of the request.
+  // Every other assertion here matches on that head, which is what would make losing this invisible.
+  it("bounds how much of the request a failure message quotes", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const huge = {
+      action: "create", resource: "dataContext[x].item",
+      values: Array.from({ length: 2000 }, (_, i) => ({ index: i, padding: "x".repeat(40) }))
+    };
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest(huge);
+    jest.advanceTimersByTime(kDefaultTimeout);
+    // cast because sendRequest resolves `unknown`; the rejection is always an Error
+    const error = await request.catch((e: Error) => e) as Error;
+
+    expect(error.message).toMatch(/^sendRequest: CODAP request exceeded/);
+    expect(error.message).toMatch(/… \(truncated\)$/);
+    expect(JSON.stringify(huge).length).toBeGreaterThan(50000);   // the request really is enormous
+    expect(error.message.length).toBeLessThan(700);
   });
 
   // `.success` read off a null reply would throw inside iframe-phone's message listener, where
@@ -464,7 +476,12 @@ describe("codapInterface.init", () => {
     lastCallback()(undefined);            // one argument: a real reply, carrying nothing
 
     await expect(initPromise).rejects.toThrow(/no result/);
-    expect(fresh.getConnectionState()).not.toBe("closed");
+
+    // asserted by using the connection, not by reading its state: "not closed" would also hold of a
+    // connection that was never established
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
   });
 
   // The endpoint is fine; the message was not. Nothing here says whether CODAP is listening.
@@ -475,7 +492,66 @@ describe("codapInterface.init", () => {
     });
 
     await expect(fresh.init({ name: "test", title: "test" } as any)).rejects.toThrow(/cloned/);
-    expect(fresh.getConnectionState()).not.toBe("closed");
+
+    // the endpoint survived the message that could not be posted, so a later request goes out on it
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  // Silence is only ever evidence of absence, so anything CODAP has already answered outranks it.
+  // An ordinary request can be issued and answered while the handshake is still outstanding.
+  it("keeps a connection CODAP answered during the handshake", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+
+    const answered = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    callbackAt(1)({ success: true });
+    await expect(answered).resolves.toEqual({ success: true });
+
+    advisoryTimeout(callbackAt(0));                       // and only then does the handshake give up
+    await expect(initPromise).rejects.toThrow(/timed out/);
+
+    expect(fresh.getConnectionState()).toBe("active");
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[y]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  // A reply is not the only thing that proves CODAP is there. A notification arrives on the same
+  // channel and marks the connection active by a different route, so it counts as evidence too.
+  it("keeps a connection CODAP sent a notification on during the handshake", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+
+    lastNotificationHandler()({ action: "notify", resource: "documentChangeNotice", values: {} },
+                              () => undefined);
+    advisoryTimeout(lastCallback());
+    await expect(initPromise).rejects.toThrow(/timed out/);
+
+    expect(fresh.getConnectionState()).toBe("active");
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  // The mirror of the case below: here the silent handshake is the one that won the race, and must
+  // still not close a connection an answered handshake established.
+  it("keeps a connection an earlier handshake established, when a later one goes silent", async () => {
+    const fresh = await freshInterface();
+    const first = fresh.init({ name: "test", title: "test" } as any);
+    const second = fresh.init({ name: "test", title: "test" } as any);
+
+    callbackAt(0)([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await expect(first).resolves.toBeDefined();
+
+    advisoryTimeout(callbackAt(1));
+    await expect(second).rejects.toThrow(/timed out/);
+
+    expect(fresh.getConnectionState()).toBe("active");
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
   });
 
   // React's StrictMode double-invokes effects, and the README initializes from one, so two
@@ -730,39 +806,6 @@ describe("codapInterface.init handshake", () => {
       await Promise.all([initPromise, request]);
     });
 
-  it("does not fail fast once the connection is established", async () => {
-    const fresh = await freshInterface();
-
-    const initPromise = fresh.init({ name: "test", title: "test" } as any);
-    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
-    await initPromise;
-
-    let settled = false;
-    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
-    request.then(() => (settled = true), () => (settled = true));
-
-    const callback = lastCallback();
-    advisoryTimeout(callback);
-    await flush();
-
-    expect(settled).toBe(false);
-
-    // settle it so its deadline timer doesn't outlive the test
-    callback({ success: true });
-    await request;
-  });
-});
-
-describe("codapInterface.sendRequest without a connection", () => {
-  // Before init() there is no connection to call, and nothing would ever settle the promise --
-  // leaving the caller awaiting forever, which is the failure this timeout handling exists to
-  // prevent.
-  it("rejects rather than leaving the caller waiting forever", async () => {
-    const fresh = await freshInterface();
-
-    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
-      .rejects.toThrow(/non-existent CODAP connection/);
-  });
 });
 
 describe("codapInterface stats", () => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -12,14 +12,29 @@ jest.mock("iframe-phone", () => ({
   }))
 }));
 
+/** Captured before any test mutates it, so these tests don't restate the library's default. */
+const kDefaultTimeout = codapInterface.getRequestTimeout();
+
+/** The callback iframe-phone would hold for the nth request, in call order. */
+function callbackAt(index: number): (response: any) => void {
+  return mockCall.mock.calls[index][1];
+}
+
 /** The callback iframe-phone would hold for the most recent request. */
 function lastCallback(): (response: any) => void {
-  return mockCall.mock.calls[mockCall.mock.calls.length - 1][1];
+  return callbackAt(mockCall.mock.calls.length - 1);
 }
 
 /** Resolves after pending microtasks flush, so promise settlement can be observed. */
 function flush() {
   return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/** A module instance with untouched connection state and stats. */
+async function freshInterface() {
+  jest.resetModules();
+  mockCall.mockClear();
+  return (await import("./codap-interface")).codapInterface;
 }
 
 async function initInterface() {
@@ -37,23 +52,11 @@ describe("codapInterface.sendRequest", () => {
     await initInterface();
   });
 
-  it("does not settle when iframe-phone reports its advisory timeout", async () => {
-    let settled = false;
-    const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
-    request.then(() => (settled = true), () => (settled = true));
-
-    // iframe-phone's 2s timer fires: callback invoked with undefined
-    lastCallback()(undefined);
-    await flush();
-
-    expect(settled).toBe(false);
-  });
-
   it("resolves with the real response when it arrives after the advisory timeout", async () => {
     const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
     const callback = lastCallback();
 
-    callback(undefined);              // advisory timeout
+    callback(undefined);              // advisory timeout — the request is still in flight
     await flush();
     callback({ success: true, values: { itemIDs: ["a", "b"] } });   // CODAP finally replies
 
@@ -94,7 +97,7 @@ describe("codapInterface.sendRequest hard timeout", () => {
 
   afterEach(() => {
     jest.useRealTimers();
-    codapInterface.setRequestTimeout(60000);
+    codapInterface.setRequestTimeout(kDefaultTimeout);
   });
 
   it("rejects if no real reply ever arrives, so a dead CODAP cannot hang the caller forever",
@@ -103,8 +106,8 @@ describe("codapInterface.sendRequest hard timeout", () => {
       const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
       const rejection = expect(request).rejects.toMatch(/exceeded/);
 
-      lastCallback()(undefined);        // advisory timeout — must not settle
-      jest.advanceTimersByTime(60000);  // hard deadline elapses
+      lastCallback()(undefined);              // advisory timeout — must not settle
+      jest.advanceTimersByTime(kDefaultTimeout);   // hard deadline elapses
 
       await rejection;
     });
@@ -123,17 +126,18 @@ describe("codapInterface.sendRequest hard timeout", () => {
   // setTimeout treats NaN and negative delays as 0, so an invalid timeout would otherwise make
   // every subsequent request reject immediately.
   it("falls back to the default when given an invalid timeout", () => {
-    codapInterface.setRequestTimeout(5000);
-    codapInterface.setRequestTimeout(NaN);
-    expect(codapInterface.getRequestTimeout()).toBe(60000);
+    [NaN, -1, 0, Infinity].forEach(invalid => {
+      codapInterface.setRequestTimeout(5000);
+      codapInterface.setRequestTimeout(invalid);
+      expect(codapInterface.getRequestTimeout()).toBe(kDefaultTimeout);
+    });
+  });
 
-    codapInterface.setRequestTimeout(5000);
-    codapInterface.setRequestTimeout(-1);
-    expect(codapInterface.getRequestTimeout()).toBe(60000);
-
-    codapInterface.setRequestTimeout(5000);
-    codapInterface.setRequestTimeout(0);
-    expect(codapInterface.getRequestTimeout()).toBe(60000);
+  // Above setTimeout's signed 32-bit ceiling the delay overflows and the timer fires immediately,
+  // which is the same silent-immediate-failure the invalid-value guard exists to prevent.
+  it("clamps a timeout above setTimeout's ceiling", () => {
+    codapInterface.setRequestTimeout(2 ** 31);
+    expect(codapInterface.getRequestTimeout()).toBe(2147483647);
   });
 
   it("reports the timeout the request was actually given, even if it changes afterwards",
@@ -149,26 +153,62 @@ describe("codapInterface.sendRequest hard timeout", () => {
       await rejection;
     });
 
-  it("does not reject after the hard deadline once the request has resolved", async () => {
+  it("clears the deadline once the request has resolved", async () => {
     jest.useFakeTimers();
     const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
 
     lastCallback()({ success: true });
     await expect(request).resolves.toEqual({ success: true });
 
-    // advancing past the deadline must not produce an unhandled rejection
-    expect(() => jest.advanceTimersByTime(120000)).not.toThrow();
+    // the settle-once contract has to cancel the timer, not merely ignore it when it fires
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});
+
+// Callers may pass a callback and discard the returned promise -- several helpers in this package
+// do, e.g. codap-helper's ensureUniqueCollectionName wraps sendRequest in a `new Promise` with no
+// reject path at all. For those callers the callback is the only signal that the request is over,
+// so it has to fire on failures too, not just on success.
+describe("codapInterface.sendRequest callback contract on failure", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    codapInterface.setRequestTimeout(kDefaultTimeout);
+  });
+
+  it("invokes the callback when the request exceeds its deadline", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback);
+    const rejection = expect(request).rejects.toMatch(/exceeded/);
+
+    jest.advanceTimersByTime(kDefaultTimeout);
+    await rejection;
+
+    expect(callerCallback).toHaveBeenCalledTimes(1);
+    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
+  });
+
+  it("invokes the callback when there is no connection", async () => {
+    const fresh = await freshInterface();
+    const callerCallback = jest.fn();
+
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
+      .rejects.toMatch(/non-existent/);
+
+    expect(callerCallback).toHaveBeenCalledTimes(1);
+    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
   });
 });
 
 describe("codapInterface.init handshake", () => {
-  // Ignoring the advisory timeout is right once CODAP has answered at least once, but the
+  // Ignoring the advisory timeout is right once a request is known to have reached CODAP, but the
   // handshake is precisely where "no reply" is evidence of "no CODAP" -- a plugin loaded outside
   // CODAP must not wait out the full request timeout to discover that.
-  it("still fails fast when nothing answers the handshake", async () => {
-    jest.resetModules();
-    mockCall.mockClear();
-    const fresh = (await import("./codap-interface")).codapInterface;
+  it("fails fast when nothing answers the handshake", async () => {
+    const fresh = await freshInterface();
 
     const initPromise = fresh.init({ name: "test", title: "test" } as any);
     lastCallback()(undefined);          // iframe-phone's 2s advisory timeout, nothing there
@@ -176,10 +216,26 @@ describe("codapInterface.init handshake", () => {
     await expect(initPromise).rejects.toMatch(/timed out/);
   });
 
+  // The fast-fail belongs to the handshake request itself, not to a window of time: an ordinary
+  // request issued while the handshake is still outstanding is a normal request, and killing it
+  // at 2s would reintroduce exactly the failure this timeout handling exists to prevent.
+  it("does not fail fast for other requests issued while the handshake is outstanding",
+    async () => {
+      const fresh = await freshInterface();
+
+      fresh.init({ name: "test", title: "test" } as any).catch(() => undefined);
+      const request = fresh.sendRequest({ action: "create", resource: "dataContext[x].item" });
+      let settled = false;
+      request.then(() => (settled = true), () => (settled = true));
+
+      callbackAt(1)(undefined);   // the ordinary request's advisory timeout
+      await flush();
+
+      expect(settled).toBe(false);
+    });
+
   it("does not fail fast once the connection is established", async () => {
-    jest.resetModules();
-    mockCall.mockClear();
-    const fresh = (await import("./codap-interface")).codapInterface;
+    const fresh = await freshInterface();
 
     const initPromise = fresh.init({ name: "test", title: "test" } as any);
     lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
@@ -199,12 +255,43 @@ describe("codapInterface.init handshake", () => {
 describe("codapInterface.sendRequest without a connection", () => {
   // Before init() there is no connection to call, and nothing would ever settle the promise --
   // leaving the caller awaiting forever, which is the failure this timeout handling exists to
-  // prevent. A fresh module gives us the pre-init state.
+  // prevent.
   it("rejects rather than leaving the caller waiting forever", async () => {
-    jest.resetModules();
-    const fresh = (await import("./codap-interface")).codapInterface;
+    const fresh = await freshInterface();
 
     await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
       .rejects.toMatch(/non-existent CODAP connection/);
+  });
+});
+
+describe("codapInterface stats", () => {
+  it("counts an advisory timeout without failing the request", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+
+    const before = fresh.getStats().countDiRplTimeout;
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    const callback = lastCallback();
+
+    callback(undefined);
+    await flush();
+    expect(fresh.getStats().countDiRplTimeout).toBe(before + 1);
+
+    callback({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+    expect(fresh.getStats().countDiRplSuccess).toBeGreaterThan(0);
+  });
+
+  it("records the time of the first data-interactive request", async () => {
+    const fresh = await freshInterface();
+    expect(fresh.getStats().timeDiFirstReq).toBeNull();
+
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+
+    expect(fresh.getStats().timeDiFirstReq).toBeInstanceOf(Date);
   });
 });

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -1,4 +1,3 @@
-import { IframePhoneRpcEndpoint } from "iframe-phone";
 import { codapInterface } from "./codap-interface";
 
 // iframe-phone invokes the callback passed to `call()` with `undefined` when its hard-coded 2s
@@ -14,12 +13,29 @@ import { codapInterface } from "./codap-interface";
 // means in production: CODAP answered with no value.
 const mockCall = jest.fn();
 
+/**
+ * The notification handler each constructed endpoint was given, in construction order. Recorded
+ * here rather than read back off the constructor mock, because `jest.resetModules()` gives the
+ * re-imported module a fresh mock: the constructor this file imported would then no longer be the
+ * one the module under test constructed, and a test reading its calls would assert against a
+ * different module instance than the one it exercised.
+ */
+const notificationHandlers: ((request: any, callback: (r: any) => void) => void)[] = [];
+
 jest.mock("iframe-phone", () => ({
-  IframePhoneRpcEndpoint: jest.fn().mockImplementation(() => ({
-    call: (message: any, callback: (response: any, noReplyYet?: Error) => void) =>
-            mockCall(message, callback)
-  }))
+  IframePhoneRpcEndpoint: jest.fn().mockImplementation((handler: any) => {
+    notificationHandlers.push(handler);
+    return {
+      call: (message: any, callback: (response: any, noReplyYet?: Error) => void) =>
+              mockCall(message, callback)
+    };
+  })
 }));
+
+/** The notification handler of the most recently constructed endpoint. */
+function lastNotificationHandler() {
+  return notificationHandlers[notificationHandlers.length - 1];
+}
 
 /** Captured before any test mutates it, so these tests don't restate the library's default. */
 const kDefaultTimeout = codapInterface.getRequestTimeout();
@@ -206,59 +222,6 @@ describe("codapInterface.sendRequest hard timeout", () => {
   });
 });
 
-// Callers may pass a callback and discard the returned promise -- several helpers in this package
-// do, e.g. codap-helper's ensureUniqueCollectionName wraps sendRequest in a `new Promise` with no
-// reject path at all. For those callers the callback is the only signal that the request is over,
-// so it has to fire on failures too, not just on success.
-describe("codapInterface.sendRequest callback contract on failure", () => {
-  afterEach(() => {
-    jest.useRealTimers();
-    codapInterface.setRequestTimeout(kDefaultTimeout);
-  });
-
-  it("invokes the callback when the request exceeds its deadline", async () => {
-    jest.useRealTimers();
-    await initInterface();
-    const callerCallback = jest.fn();
-
-    jest.useFakeTimers();
-    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback);
-    const rejection = expect(request).rejects.toThrow(/exceeded/);
-
-    jest.advanceTimersByTime(kDefaultTimeout);
-    await rejection;
-
-    expect(callerCallback).toHaveBeenCalledTimes(1);
-    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
-  });
-
-  it("invokes the callback when there is no connection", async () => {
-    const fresh = await freshInterface();
-    const callerCallback = jest.fn();
-
-    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
-      .rejects.toThrow(/non-existent/);
-
-    expect(callerCallback).toHaveBeenCalledTimes(1);
-    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
-  });
-
-  it("invokes the callback on a connection that has been destroyed", async () => {
-    const fresh = await freshInterface();
-    const initPromise = fresh.init({ name: "test", title: "test" } as any);
-    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
-    await initPromise;
-    fresh.destroy();
-
-    const callerCallback = jest.fn();
-    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
-      .rejects.toThrow(/closed/);
-
-    expect(callerCallback).toHaveBeenCalledTimes(1);
-    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
-  });
-});
-
 // Two failed review rounds turned on the same question -- is the contract true on *every* path? --
 // answered each time by checking the paths someone had thought of. This enumerates them instead.
 // Every way a request can settle gets one case, and each asserts all three parts of the contract
@@ -281,14 +244,17 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     jest.useRealTimers();
     await initInterface();
     const callerCallback = jest.fn();
+    const message = { action: "get", resource: "dataContext[x]" };
 
     jest.useFakeTimers();
-    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
-                                               callerCallback);
+    const request = codapInterface.sendRequest(message, callerCallback);
     lastCallback()({ success: true, values: { id: 1 } });
 
     await expect(request).resolves.toEqual({ success: true, values: { id: 1 } });
     expectSettledOnce(callerCallback, { success: true, values: { id: 1 } });
+    // the documented second argument: "followed by the original request". Asserted here rather than
+    // in every case, where expect.anything() keeps the failure being described the settling one.
+    expect(callerCallback).toHaveBeenCalledWith(expect.anything(), message);
   });
 
   it("CODAP declines: still resolves, since {success:false} is an answer", async () => {
@@ -440,8 +406,9 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     await request;
   });
 
-  // A duplicated reply is a real possibility at the iframe-phone level, and settling once has to
-  // cover the callback as well as the promise.
+  // iframe-phone clears its pending callback as soon as it invokes it, so it will not deliver the
+  // same reply twice. This exercises the settle-once guard directly rather than a scenario the
+  // library can produce: settling once has to cover the callback, not just the promise.
   it("a duplicated reply notifies the callback only once", async () => {
     jest.useRealTimers();
     await initInterface();
@@ -484,10 +451,10 @@ describe("codapInterface.sendRequest settles every path through the contract", (
 // destroy() reports the state it puts the connection in, so getConnectionState() is honest and new
 // requests are refused. That makes init() responsible for clearing it: without the reset, the
 // handshake below would itself be refused and the connection could never be reestablished.
-// A handshake that draws no reply leaves a connection object nothing is listening to. Left in place
-// it looks live, so every later request would be sent and then wait out the full deadline -- a
-// minute per request for a plugin that has already been told it is not running inside CODAP.
-describe("codapInterface.init when the handshake fails", () => {
+// init() is the entry point every plugin calls first, and it does not go through sendRequest's
+// contract, so it needs its own coverage of the same questions: does it always settle, does it
+// report failure, and does it leave the plugin able to proceed either way.
+describe("codapInterface.init", () => {
   it("refuses later requests instead of letting each wait out the deadline", async () => {
     const fresh = await freshInterface();
     const initPromise = fresh.init({ name: "test", title: "test" } as any);
@@ -516,6 +483,26 @@ describe("codapInterface.init when the handshake fails", () => {
 
     expect(initCallback).toHaveBeenCalledTimes(1);
     expect(initCallback).toHaveBeenCalledWith(undefined);
+  });
+
+  // The handshake's own callbacks run after it settles, so what they throw is the caller's bug and
+  // not a failure to connect. Invoked before `resolve`, a throwing stateHandler would leave init()
+  // unsettled forever, with the exception discarded into a promise nothing observes.
+  it("settles even when the caller's stateHandler throws", async () => {
+    const fresh = await freshInterface();
+    const scheduled: Array<() => void> = [];
+    const spy = jest.spyOn(window, "queueMicrotask")
+                    .mockImplementation((thunk: () => void) => { scheduled.push(thunk); });
+    const boom = new Error("stateHandler bug");
+
+    const initPromise = fresh.init({ name: "test", title: "test",
+                                     stateHandler: () => { throw boom; } } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: { a: 1 } } }]);
+
+    await expect(initPromise).resolves.toEqual({ a: 1 });
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toThrow(boom);
+    spy.mockRestore();
   });
 
   it("can be retried, so a plugin is not stranded by one failed handshake", async () => {
@@ -552,10 +539,9 @@ describe("codapInterface.destroy", () => {
     await initPromise;
     fresh.destroy();
 
-    // the handler iframe-phone was constructed with, invoked as a CODAP notification would
-    const notificationHandler = (IframePhoneRpcEndpoint as jest.Mock).mock.calls[0][0];
-    notificationHandler({ action: "notify", resource: "documentChangeNotice", values: {} },
-                        () => undefined);
+    // the handler this instance's endpoint was constructed with, invoked as CODAP would
+    lastNotificationHandler()({ action: "notify", resource: "documentChangeNotice", values: {} },
+                              () => undefined);
 
     expect(fresh.getConnectionState()).toBe("closed");
     await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -120,6 +120,35 @@ describe("codapInterface.sendRequest hard timeout", () => {
     await rejection;
   });
 
+  // setTimeout treats NaN and negative delays as 0, so an invalid timeout would otherwise make
+  // every subsequent request reject immediately.
+  it("falls back to the default when given an invalid timeout", () => {
+    codapInterface.setRequestTimeout(5000);
+    codapInterface.setRequestTimeout(NaN);
+    expect(codapInterface.getRequestTimeout()).toBe(60000);
+
+    codapInterface.setRequestTimeout(5000);
+    codapInterface.setRequestTimeout(-1);
+    expect(codapInterface.getRequestTimeout()).toBe(60000);
+
+    codapInterface.setRequestTimeout(5000);
+    codapInterface.setRequestTimeout(0);
+    expect(codapInterface.getRequestTimeout()).toBe(60000);
+  });
+
+  it("reports the timeout the request was actually given, even if it changes afterwards",
+    async () => {
+      codapInterface.setRequestTimeout(5000);
+      jest.useFakeTimers();
+      const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
+      const rejection = expect(request).rejects.toMatch(/exceeded 5000ms/);
+
+      codapInterface.setRequestTimeout(30000);   // must not change this request's report
+      jest.advanceTimersByTime(5000);
+
+      await rejection;
+    });
+
   it("does not reject after the hard deadline once the request has resolved", async () => {
     jest.useFakeTimers();
     const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
@@ -129,5 +158,18 @@ describe("codapInterface.sendRequest hard timeout", () => {
 
     // advancing past the deadline must not produce an unhandled rejection
     expect(() => jest.advanceTimersByTime(120000)).not.toThrow();
+  });
+});
+
+describe("codapInterface.sendRequest without a connection", () => {
+  // Before init() there is no connection to call, and nothing would ever settle the promise --
+  // leaving the caller awaiting forever, which is the failure this timeout handling exists to
+  // prevent. A fresh module gives us the pre-init state.
+  it("rejects rather than leaving the caller waiting forever", async () => {
+    jest.resetModules();
+    const fresh = (await import("./codap-interface")).codapInterface;
+
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
+      .rejects.toMatch(/non-existent CODAP connection/);
   });
 });

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -58,7 +58,7 @@ function advisoryTimeout(callback: PhoneCallback) {
   callback(undefined, new Error("IframePhone timed out waiting for reply"));
 }
 
-/** Resolves after pending microtasks flush, so promise settlement can be observed. */
+/** Yields to the task queue, so anything already queued -- microtasks included -- has run. */
 function flush() {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -148,30 +148,6 @@ describe("codapInterface.sendRequest", () => {
     await expect(request).resolves.toEqual({ success: true, values: { itemIDs: ["a", "b"] } });
   });
 
-  it("does not invoke the caller's callback with undefined on the advisory timeout", async () => {
-    const callerCallback = jest.fn();
-    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback);
-    const callback = lastCallback();
-
-    advisoryTimeout(callback);
-    await flush();
-    expect(callerCallback).not.toHaveBeenCalled();
-
-    callback({ success: true });
-    await request;
-    expect(callerCallback).toHaveBeenCalledTimes(1);
-    expect(callerCallback).toHaveBeenCalledWith({ success: true }, expect.anything());
-  });
-
-  it("still resolves only once when the real reply arrives twice", async () => {
-    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
-    const callback = lastCallback();
-
-    callback({ success: true, values: 1 });
-    callback({ success: true, values: 2 });
-
-    await expect(request).resolves.toEqual({ success: true, values: 1 });
-  });
 });
 
 describe("codapInterface.sendRequest hard timeout", () => {
@@ -184,18 +160,6 @@ describe("codapInterface.sendRequest hard timeout", () => {
     jest.useRealTimers();
     codapInterface.setRequestTimeout(kDefaultTimeout);
   });
-
-  it("rejects if no real reply ever arrives, so a dead CODAP cannot hang the caller forever",
-    async () => {
-      jest.useFakeTimers();
-      const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
-      const rejection = expect(request).rejects.toThrow(/exceeded/);
-
-      advisoryTimeout(lastCallback());        // advisory timeout — must not settle
-      jest.advanceTimersByTime(kDefaultTimeout);   // hard deadline elapses
-
-      await rejection;
-    });
 
   it("uses a configurable hard timeout", async () => {
     codapInterface.setRequestTimeout(5000);
@@ -238,41 +202,6 @@ describe("codapInterface.sendRequest hard timeout", () => {
       await rejection;
     });
 
-  // `connection.call` can throw synchronously -- an uncloneable value in the message makes
-  // postMessage raise DataCloneError. Left to escape the executor it would reject the promise
-  // without passing through settle(), which is the one path on which the callback contract could
-  // still be false: the caller would get a rejection and no notification. It is also why the
-  // deadline is armed after the call rather than before -- armed first, the timer would outlive the
-  // throw and report a failure a minute after the caller had handled it.
-  it("settles through the contract when the request throws synchronously", async () => {
-    const callerCallback = jest.fn();
-    mockCall.mockImplementationOnce(() => {
-      throw new DOMException("value could not be cloned", "DataCloneError");
-    });
-
-    jest.useFakeTimers();
-    await expect(codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" },
-                                            callerCallback)).rejects.toThrow(/cloned/);
-
-    expect(callerCallback).toHaveBeenCalledTimes(1);
-    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
-
-    // no deadline was armed, so nothing can fire later against a request that has already settled
-    expect(jest.getTimerCount()).toBe(0);
-    jest.advanceTimersByTime(kDefaultTimeout);
-    expect(callerCallback).toHaveBeenCalledTimes(1);
-  });
-
-  it("clears the deadline once the request has resolved", async () => {
-    jest.useFakeTimers();
-    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
-
-    lastCallback()({ success: true });
-    await expect(request).resolves.toEqual({ success: true });
-
-    // the settle-once contract has to cancel the timer, not merely ignore it when it fires
-    expect(jest.getTimerCount()).toBe(0);
-  });
 });
 
 // Two failed review rounds turned on the same question -- is the contract true on *every* path? --
@@ -455,8 +384,12 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     expect(settled).toBe(false);
     expect(callerCallback).not.toHaveBeenCalled();
 
-    lastCallback()({ success: true });     // settle it so no deadline outlives the test
-    await request;
+    // and the reply that follows the probe settles it normally, which is the whole point of
+    // ignoring the probe: the request was in flight, not failed
+    jest.useFakeTimers();
+    lastCallback()({ success: true, values: { itemIDs: ["a"] } });
+    await expect(request).resolves.toEqual({ success: true, values: { itemIDs: ["a"] } });
+    expectSettledOnce(callerCallback, { success: true, values: { itemIDs: ["a"] } });
   });
 
   // iframe-phone clears its pending callback as soon as it invokes it, so it will not deliver the
@@ -508,6 +441,42 @@ describe("codapInterface.sendRequest settles every path through the contract", (
 // contract, so it needs its own coverage of the same questions: does it always settle, does it
 // report failure, and does it leave the plugin able to proceed either way.
 describe("codapInterface.init", () => {
+  // Closing the connection is right when nothing answered, and wrong whenever CODAP did. A decline
+  // is CODAP answering: it is there and listening, so the connection stays usable and only the
+  // handshake fails.
+  it("leaves the connection usable when CODAP declines the handshake", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: false, values: { error: "no frame" } }]);
+
+    await expect(initPromise).rejects.toThrow(/no frame/);
+    expect(fresh.getConnectionState()).not.toBe("closed");
+
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
+  // React's StrictMode double-invokes effects, and the README initializes from one, so two
+  // handshakes can be outstanding at once. The loser must not close the winner's connection: an
+  // init() that resolved and then handed back a dead connection reports nothing at all.
+  it("does not let one handshake close the connection another established", async () => {
+    const fresh = await freshInterface();
+    const first = fresh.init({ name: "test", title: "test" } as any);
+    const second = fresh.init({ name: "test", title: "test" } as any);
+
+    callbackAt(1)([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await expect(second).resolves.toBeDefined();
+
+    advisoryTimeout(callbackAt(0));                       // the first handshake gives up
+    await expect(first).rejects.toThrow(/timed out/);
+
+    expect(fresh.getConnectionState()).toBe("active");
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
   it("refuses later requests instead of letting each wait out the deadline", async () => {
     const fresh = await freshInterface();
     const initPromise = fresh.init({ name: "test", title: "test" } as any);
@@ -553,6 +522,26 @@ describe("codapInterface.init", () => {
     lastCallback()([{ success: true }, { success: true, values: { savedState: { a: 1 } } }]);
 
     await expect(initPromise).resolves.toEqual({ a: 1 });
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toThrow(boom);
+    spy.mockRestore();
+  });
+
+  // The saved state comes out of a CODAP document, and merging it is the first thing init() does
+  // with it. A throwing getter there used to leave init() pending forever, for the same reason a
+  // throwing stateHandler did: the exception went into a promise chain nothing observes.
+  it("settles even when merging the saved state throws", async () => {
+    const fresh = await freshInterface();
+    const scheduled: Array<() => void> = [];
+    const spy = jest.spyOn(window, "queueMicrotask")
+                    .mockImplementation((thunk: () => void) => { scheduled.push(thunk); });
+    const boom = new Error("unreadable saved state");
+    const savedState = { get poisoned() { throw boom; } };
+
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState } }]);
+
+    await expect(initPromise).resolves.toBe(savedState);
     expect(scheduled).toHaveLength(1);
     expect(scheduled[0]).toThrow(boom);
     spy.mockRestore();
@@ -622,7 +611,7 @@ describe("codapInterface.destroy", () => {
 
 // A throw from the caller's callback is a consumer bug, not a failure of the request -- which has
 // already settled by then. It must not escape into the stack that invoked the callback (iframe-
-// phone's listener, the deadline timer, this executor), so it is rethrown on a fresh task, where it
+// phone's listener, the deadline timer, this executor), so it is rethrown from a microtask, where it
 // stays an uncaught error that window.onerror and error reporters can see. These tests capture what
 // is scheduled rather than letting it throw, which would fail the suite it is meant to be reported
 // through.
@@ -762,17 +751,19 @@ describe("codapInterface stats", () => {
     lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
     await initPromise;
 
-    const before = fresh.getStats().countDiRplTimeout;
+    const before = { ...fresh.getStats() };
     const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
     const callback = lastCallback();
 
     advisoryTimeout(callback);
     await flush();
-    expect(fresh.getStats().countDiRplTimeout).toBe(before + 1);
+    expect(fresh.getStats().countDiRplTimeout).toBe(before.countDiRplTimeout + 1);
 
     callback({ success: true });
     await expect(request).resolves.toEqual({ success: true });
-    expect(fresh.getStats().countDiRplSuccess).toBeGreaterThan(0);
+    // captured rather than `toBeGreaterThan(0)`, which the init() handshake satisfies on its own and
+    // which therefore said nothing about the request under test
+    expect(fresh.getStats().countDiRplSuccess).toBe(before.countDiRplSuccess + 1);
   });
 
   // A batched request is answered with an array, which has no top-level `success` to read, so every
@@ -797,6 +788,41 @@ describe("codapInterface stats", () => {
 
     expect(fresh.getStats().countDiRplSuccess).toBe(0);
     expect(fresh.getStats().countDiRplFail).toBe(1);
+  });
+
+  // The counters document an arithmetic relationship, which nothing asserted, which is how it came
+  // to be false: a request refused before it could be sent incremented only the failure counter, so
+  // the "still in flight" figure went negative.
+  it("counts a refused request, so the in-flight arithmetic holds", async () => {
+    const fresh = await freshInterface();
+
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
+      .rejects.toThrow(/non-existent/);
+
+    const s = fresh.getStats();
+    expect(s.countDiReq).toBe(1);
+    expect(s.countDiReqFailed).toBe(1);
+    expect(s.countDiReq - s.countDiRplSuccess - s.countDiRplFail - s.countDiReqFailed).toBe(0);
+  });
+
+  it("keeps the in-flight arithmetic true across a mix of outcomes", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+
+    const declined = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: false });
+    await declined;
+
+    const inFlight = fresh.sendRequest({ action: "get", resource: "dataContext[y]" });
+    inFlight.catch(() => undefined);          // still outstanding at the assertion below
+
+    const s = fresh.getStats();
+    expect(s.countDiReq - s.countDiRplSuccess - s.countDiRplFail - s.countDiReqFailed).toBe(1);
+
+    lastCallback()({ success: true });        // settle it so no deadline outlives the test
+    await inFlight;
   });
 
   it("records the time of the first data-interactive request", async () => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -98,6 +98,37 @@ describe("the callback type", () => {
     // `undefined` it refuses to admit is precisely the TypeError the type exists to prevent
     expect([cannotFail, canFail].every(fn => typeof fn === "function")).toBe(true);
   });
+
+  // CODAP answers a batched request with one result per request, so a callback written for a single
+  // result would read `.success` off an array and get `undefined` -- a silent wrong answer, on the
+  // one path where the contract could still mislead. The message type decides which callback shape
+  // is accepted, so neither pairing can be got wrong.
+  //
+  // Declared, never called: these are compile-time assertions, and running them would issue real
+  // requests. If the pairing ever stops being enforced, the @ts-expect-error directives below stop
+  // being errors and this file fails to compile.
+  it("pairs the callback shape with the message shape", () => {
+    const single = (result?: IResult) => result?.success;
+    const batch = (results?: IResult[]) => results?.length;
+    const message = { action: "get", resource: "dataContext[x]" };
+    const batched = [message, message];
+    const untyped: any = message;
+
+    function compileOnly() {
+      codapInterface.sendRequest(message, single);
+      codapInterface.sendRequest(batched, batch);
+      // an `any` message cannot be discriminated, so both shapes stay available rather than
+      // arbitrarily rejecting one
+      codapInterface.sendRequest(untyped, single);
+      codapInterface.sendRequest(untyped, batch);
+      // @ts-expect-error a batched request answers with an array, which this callback cannot read
+      codapInterface.sendRequest(batched, single);
+      // @ts-expect-error a single request answers with one result, not an array
+      codapInterface.sendRequest(message, batch);
+    }
+
+    expect(typeof compileOnly).toBe("function");
+  });
 });
 
 describe("codapInterface.sendRequest", () => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -1,3 +1,4 @@
+import type { IResult } from "./codap-helper";
 import { codapInterface } from "./codap-interface";
 
 // iframe-phone invokes the callback passed to `call()` with `undefined` when its hard-coded 2s
@@ -77,6 +78,27 @@ async function initInterface() {
   await initPromise;
   mockCall.mockClear();
 }
+
+// The contract's central claim is that a callback receives `undefined` when a request fails, so a
+// callback that cannot accept `undefined` is wrong and should say so at build time rather than throw
+// a TypeError on a failure path in front of users. These assert that at the type level: if the
+// parameter ever loosens back to `any`, the @ts-expect-error stops being an error and this file
+// fails to compile.
+describe("the callback type", () => {
+  // Read off sendRequest itself rather than the exported alias, so this pins the signature a
+  // consumer is actually held to.
+  type Accepted = NonNullable<Parameters<typeof codapInterface.sendRequest>[1]>;
+
+  it("rejects a callback that cannot receive a failure", () => {
+    // @ts-expect-error a callback typed for the response alone cannot handle a failed request
+    const cannotFail: Accepted = (result: IResult) => result.success;
+    const canFail: Accepted = (result?: IResult) => result?.success;
+
+    // never invoked: the assertions above are the test, and calling `cannotFail` with the
+    // `undefined` it refuses to admit is precisely the TypeError the type exists to prevent
+    expect([cannotFail, canFail].every(fn => typeof fn === "function")).toBe(true);
+  });
+});
 
 describe("codapInterface.sendRequest", () => {
   beforeEach(async () => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -311,7 +311,7 @@ describe("codapInterface.sendRequest settles every path through the contract", (
   it("CODAP answers with no value: rejects rather than resolving with undefined", async () => {
     jest.useRealTimers();
     await initInterface();
-    const before = codapInterface.getStats().countDiRplFail;
+    const before = { ...codapInterface.getStats() };
     const callerCallback = jest.fn();
 
     jest.useFakeTimers();
@@ -321,7 +321,9 @@ describe("codapInterface.sendRequest settles every path through the contract", (
 
     await expect(request).rejects.toThrow(/answered with no result/);
     expectSettledOnce(callerCallback, undefined);
-    expect(codapInterface.getStats().countDiRplFail).toBe(before + 1);
+    // a failure, not a decline: countDiRplFail is for a CODAP answer of {success: false}
+    expect(codapInterface.getStats().countDiReqFailed).toBe(before.countDiReqFailed + 1);
+    expect(codapInterface.getStats().countDiRplFail).toBe(before.countDiRplFail);
   });
 
   it("the deadline passes: rejects, and says so in the stats", async () => {
@@ -379,6 +381,41 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
       .rejects.toThrow(/closed/);
 
+    expectSettledOnce(callerCallback, undefined);
+  });
+
+  // A message can be structured-cloneable and still not JSON-serializable -- a cycle, or a BigInt --
+  // so it is genuinely sent, and only describing it in a failure message fails. Building that
+  // message unguarded threw while the request was being failed, which left it settled by nothing.
+  it("fails a request whose message cannot be serialized for the error", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const cyclic: any = { action: "create", resource: "dataContext[x].item" };
+    cyclic.values = { self: cyclic };
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest(cyclic, callerCallback);
+    const rejection = expect(request).rejects.toThrow(/exceeded/);
+    jest.advanceTimersByTime(kDefaultTimeout);
+    await rejection;
+
+    expectSettledOnce(callerCallback, undefined);
+  });
+
+  // `.success` read off a null reply would throw inside iframe-phone's message listener, where
+  // nothing settles the request -- so null is as empty an answer as undefined.
+  it("treats a null reply as an answer carrying no result", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    lastCallback()(null);
+
+    await expect(request).rejects.toThrow(/answered with no result/);
     expectSettledOnce(callerCallback, undefined);
   });
 
@@ -447,6 +484,52 @@ describe("codapInterface.sendRequest settles every path through the contract", (
 // destroy() reports the state it puts the connection in, so getConnectionState() is honest and new
 // requests are refused. That makes init() responsible for clearing it: without the reset, the
 // handshake below would itself be refused and the connection could never be reestablished.
+// A handshake that draws no reply leaves a connection object nothing is listening to. Left in place
+// it looks live, so every later request would be sent and then wait out the full deadline -- a
+// minute per request for a plugin that has already been told it is not running inside CODAP.
+describe("codapInterface.init when the handshake fails", () => {
+  it("refuses later requests instead of letting each wait out the deadline", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    advisoryTimeout(lastCallback());
+    await expect(initPromise).rejects.toThrow(/timed out/);
+
+    expect(fresh.getConnectionState()).toBe("closed");
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
+      .rejects.toThrow(/closed/);
+  });
+
+  it("rejects with an Error, like every other failure", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    advisoryTimeout(lastCallback());
+
+    await expect(initPromise).rejects.toBeInstanceOf(Error);
+  });
+
+  it("reports the failure to init's callback, which otherwise only hears about success", async () => {
+    const fresh = await freshInterface();
+    const initCallback = jest.fn();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any, initCallback);
+    advisoryTimeout(lastCallback());
+    await expect(initPromise).rejects.toThrow(/timed out/);
+
+    expect(initCallback).toHaveBeenCalledTimes(1);
+    expect(initCallback).toHaveBeenCalledWith(undefined);
+  });
+
+  it("can be retried, so a plugin is not stranded by one failed handshake", async () => {
+    const fresh = await freshInterface();
+    const failed = fresh.init({ name: "test", title: "test" } as any);
+    advisoryTimeout(lastCallback());
+    await expect(failed).rejects.toThrow(/timed out/);
+
+    const retry = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await expect(retry).resolves.toBeDefined();
+  });
+});
+
 describe("codapInterface.destroy", () => {
   it("reports the connection as closed", async () => {
     const fresh = await freshInterface();

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -161,6 +161,41 @@ describe("codapInterface.sendRequest hard timeout", () => {
   });
 });
 
+describe("codapInterface.init handshake", () => {
+  // Ignoring the advisory timeout is right once CODAP has answered at least once, but the
+  // handshake is precisely where "no reply" is evidence of "no CODAP" -- a plugin loaded outside
+  // CODAP must not wait out the full request timeout to discover that.
+  it("still fails fast when nothing answers the handshake", async () => {
+    jest.resetModules();
+    mockCall.mockClear();
+    const fresh = (await import("./codap-interface")).codapInterface;
+
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()(undefined);          // iframe-phone's 2s advisory timeout, nothing there
+
+    await expect(initPromise).rejects.toMatch(/timed out/);
+  });
+
+  it("does not fail fast once the connection is established", async () => {
+    jest.resetModules();
+    mockCall.mockClear();
+    const fresh = (await import("./codap-interface")).codapInterface;
+
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+
+    let settled = false;
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    request.then(() => (settled = true), () => (settled = true));
+
+    lastCallback()(undefined);
+    await flush();
+
+    expect(settled).toBe(false);
+  });
+});
+
 describe("codapInterface.sendRequest without a connection", () => {
   // Before init() there is no connection to call, and nothing would ever settle the promise --
   // leaving the caller awaiting forever, which is the failure this timeout handling exists to

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -457,6 +457,27 @@ describe("codapInterface.init", () => {
     await expect(request).resolves.toEqual({ success: true });
   });
 
+  // CODAP answering with nothing is still CODAP answering: the reply arrived, so something is there.
+  it("leaves the connection usable when CODAP answers the handshake with no value", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()(undefined);            // one argument: a real reply, carrying nothing
+
+    await expect(initPromise).rejects.toThrow(/no result/);
+    expect(fresh.getConnectionState()).not.toBe("closed");
+  });
+
+  // The endpoint is fine; the message was not. Nothing here says whether CODAP is listening.
+  it("leaves the connection usable when the handshake cannot be posted", async () => {
+    const fresh = await freshInterface();
+    mockCall.mockImplementationOnce(() => {
+      throw new DOMException("value could not be cloned", "DataCloneError");
+    });
+
+    await expect(fresh.init({ name: "test", title: "test" } as any)).rejects.toThrow(/cloned/);
+    expect(fresh.getConnectionState()).not.toBe("closed");
+  });
+
   // React's StrictMode double-invokes effects, and the README initializes from one, so two
   // handshakes can be outstanding at once. The loser must not close the winner's connection: an
   // init() that resolved and then handed back a dead connection reports nothing at all.

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -423,9 +423,11 @@ describe("codapInterface.sendRequest settles every path through the contract", (
     expectSettledOnce(callerCallback, { success: true, values: 1 });
   });
 
-  // A reply can arrive after the deadline has already failed the request. It must not revive it,
-  // report a success against it, or mark a connection the caller has given up on as live.
-  it("a reply after the deadline changes nothing", async () => {
+  // A reply can arrive after the deadline has already failed the request. It must not revive that
+  // request or report a success against it. It is still evidence that CODAP is there, which is a
+  // separate matter and deliberately not suppressed -- see the by-time half of the rule on
+  // markConnectionActive.
+  it("a reply after the deadline does not revive the request", async () => {
     jest.useRealTimers();
     await initInterface();
     const callerCallback = jest.fn();
@@ -575,6 +577,21 @@ describe("codapInterface.init", () => {
     await expect(request).resolves.toEqual({ success: true });
   });
 
+  // A plugin can tear down while its handshake is still outstanding -- unmounting under StrictMode
+  // does exactly that. Resolving then would hand back a connection the caller has already closed,
+  // and merge saved state into a plugin that is going away.
+  it("fails rather than resolving against a connection destroy() has closed", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+
+    fresh.destroy();
+    lastCallback()([{ success: true }, { success: true, values: { savedState: { a: 1 } } }]);
+
+    await expect(initPromise).rejects.toThrow(/destroyed/);
+    expect(fresh.getConnectionState()).toBe("closed");
+    expect(fresh.getInteractiveState()).toEqual({});
+  });
+
   // React's StrictMode double-invokes effects, and the README initializes from one, so two
   // handshakes can be outstanding at once. The loser must not close the winner's connection: an
   // init() that resolved and then handed back a dead connection reports nothing at all.
@@ -675,6 +692,29 @@ describe("codapInterface.init", () => {
     lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
     await expect(retry).resolves.toBeDefined();
   });
+
+  // The fast-fail belongs to the handshake request itself, not to a window of time: an
+  // ordinary request issued while the handshake is outstanding is a normal request, and
+  // killing it at 2s would reintroduce the failure this deadline handling exists to prevent.
+  it("does not fail fast for other requests issued while the handshake is outstanding",
+    async () => {
+      const fresh = await freshInterface();
+
+      const initPromise = fresh.init({ name: "test", title: "test" } as any);
+      const request = fresh.sendRequest({ action: "create", resource: "dataContext[x].item" });
+      let settled = false;
+      request.then(() => (settled = true), () => (settled = true));
+
+      advisoryTimeout(callbackAt(1));   // the ordinary request's advisory timeout
+      await flush();
+
+      expect(settled).toBe(false);
+
+      // settle both so neither leaves its deadline timer running past the test
+      callbackAt(0)([{ success: true }, { success: true, values: { savedState: {} } }]);
+      callbackAt(1)({ success: true });
+      await Promise.all([initPromise, request]);
+    });
 });
 
 describe("codapInterface.destroy", () => {
@@ -791,43 +831,6 @@ describe("codapInterface.sendRequest callback errors", () => {
   });
 });
 
-describe("codapInterface.init handshake", () => {
-  // Ignoring the advisory timeout is right once a request is known to have reached CODAP, but the
-  // handshake is precisely where "no reply" is evidence of "no CODAP" -- a plugin loaded outside
-  // CODAP must not wait out the full request timeout to discover that.
-  it("fails fast when nothing answers the handshake", async () => {
-    const fresh = await freshInterface();
-
-    const initPromise = fresh.init({ name: "test", title: "test" } as any);
-    advisoryTimeout(lastCallback());    // iframe-phone's 2s advisory timeout, nothing there
-
-    await expect(initPromise).rejects.toThrow(/timed out/);
-  });
-
-  // The fast-fail belongs to the handshake request itself, not to a window of time: an ordinary
-  // request issued while the handshake is still outstanding is a normal request, and killing it
-  // at 2s would reintroduce exactly the failure this timeout handling exists to prevent.
-  it("does not fail fast for other requests issued while the handshake is outstanding",
-    async () => {
-      const fresh = await freshInterface();
-
-      const initPromise = fresh.init({ name: "test", title: "test" } as any);
-      const request = fresh.sendRequest({ action: "create", resource: "dataContext[x].item" });
-      let settled = false;
-      request.then(() => (settled = true), () => (settled = true));
-
-      advisoryTimeout(callbackAt(1));   // the ordinary request's advisory timeout
-      await flush();
-
-      expect(settled).toBe(false);
-
-      // settle both so neither leaves its deadline timer running past the test
-      callbackAt(0)([{ success: true }, { success: true, values: { savedState: {} } }]);
-      callbackAt(1)({ success: true });
-      await Promise.all([initPromise, request]);
-    });
-
-});
 
 describe("codapInterface stats", () => {
   it("counts an advisory timeout without failing the request", async () => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -1,28 +1,44 @@
+import { IframePhoneRpcEndpoint } from "iframe-phone";
 import { codapInterface } from "./codap-interface";
 
 // iframe-phone invokes the callback passed to `call()` with `undefined` when its hard-coded 2s
 // timer expires, but it does NOT cancel the request or forget the callback — when CODAP finally
 // replies it invokes the same callback a second time with the real value. These tests capture
 // that callback so both invocations can be simulated.
+//
+// The two invocations are distinguishable, and these tests rely on it exactly as the code does:
+// iframe-phone passes a second argument for the advisory timer only
+// (`iframe-phone-rpc-endpoint.js`: `callback(undefined, new Error(...))` for the timer,
+// `callback.call(undefined, message.value)` for the real reply). `advisoryTimeout` below is the
+// only way these tests simulate the timer, so a bare `callback(undefined)` in a test means what it
+// means in production: CODAP answered with no value.
 const mockCall = jest.fn();
 
 jest.mock("iframe-phone", () => ({
   IframePhoneRpcEndpoint: jest.fn().mockImplementation(() => ({
-    call: (message: any, callback: (response: any) => void) => mockCall(message, callback)
+    call: (message: any, callback: (response: any, noReplyYet?: Error) => void) =>
+            mockCall(message, callback)
   }))
 }));
 
 /** Captured before any test mutates it, so these tests don't restate the library's default. */
 const kDefaultTimeout = codapInterface.getRequestTimeout();
 
+type PhoneCallback = (response: any, noReplyYet?: Error) => void;
+
 /** The callback iframe-phone would hold for the nth request, in call order. */
-function callbackAt(index: number): (response: any) => void {
+function callbackAt(index: number): PhoneCallback {
   return mockCall.mock.calls[index][1];
 }
 
 /** The callback iframe-phone would hold for the most recent request. */
-function lastCallback(): (response: any) => void {
+function lastCallback(): PhoneCallback {
   return callbackAt(mockCall.mock.calls.length - 1);
+}
+
+/** Simulates iframe-phone's advisory 2s timer firing, exactly as the library reports it. */
+function advisoryTimeout(callback: PhoneCallback) {
+  callback(undefined, new Error("IframePhone timed out waiting for reply"));
 }
 
 /** Resolves after pending microtasks flush, so promise settlement can be observed. */
@@ -56,7 +72,7 @@ describe("codapInterface.sendRequest", () => {
     const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
     const callback = lastCallback();
 
-    callback(undefined);              // advisory timeout — the request is still in flight
+    advisoryTimeout(callback);        // the request is still in flight
     await flush();
     callback({ success: true, values: { itemIDs: ["a", "b"] } });   // CODAP finally replies
 
@@ -68,7 +84,7 @@ describe("codapInterface.sendRequest", () => {
     const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback);
     const callback = lastCallback();
 
-    callback(undefined);
+    advisoryTimeout(callback);
     await flush();
     expect(callerCallback).not.toHaveBeenCalled();
 
@@ -104,9 +120,9 @@ describe("codapInterface.sendRequest hard timeout", () => {
     async () => {
       jest.useFakeTimers();
       const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
-      const rejection = expect(request).rejects.toMatch(/exceeded/);
+      const rejection = expect(request).rejects.toThrow(/exceeded/);
 
-      lastCallback()(undefined);              // advisory timeout — must not settle
+      advisoryTimeout(lastCallback());        // advisory timeout — must not settle
       jest.advanceTimersByTime(kDefaultTimeout);   // hard deadline elapses
 
       await rejection;
@@ -116,7 +132,7 @@ describe("codapInterface.sendRequest hard timeout", () => {
     codapInterface.setRequestTimeout(5000);
     jest.useFakeTimers();
     const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
-    const rejection = expect(request).rejects.toMatch(/exceeded/);
+    const rejection = expect(request).rejects.toThrow(/exceeded/);
 
     jest.advanceTimersByTime(5000);
 
@@ -145,7 +161,7 @@ describe("codapInterface.sendRequest hard timeout", () => {
       codapInterface.setRequestTimeout(5000);
       jest.useFakeTimers();
       const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
-      const rejection = expect(request).rejects.toMatch(/exceeded 5000ms/);
+      const rejection = expect(request).rejects.toThrow(/exceeded 5000ms/);
 
       codapInterface.setRequestTimeout(30000);   // must not change this request's report
       jest.advanceTimersByTime(5000);
@@ -154,10 +170,12 @@ describe("codapInterface.sendRequest hard timeout", () => {
     });
 
   // `connection.call` can throw synchronously -- an uncloneable value in the message makes
-  // postMessage raise DataCloneError -- and that rejects the promise directly, without going
-  // through settle(). A deadline armed before the call would survive that and fire a minute later,
-  // reporting a failure the caller had already handled.
-  it("leaves no deadline behind when the request throws synchronously", async () => {
+  // postMessage raise DataCloneError. Left to escape the executor it would reject the promise
+  // without passing through settle(), which is the one path on which the callback contract could
+  // still be false: the caller would get a rejection and no notification. It is also why the
+  // deadline is armed after the call rather than before -- armed first, the timer would outlive the
+  // throw and report a failure a minute after the caller had handled it.
+  it("settles through the contract when the request throws synchronously", async () => {
     const callerCallback = jest.fn();
     mockCall.mockImplementationOnce(() => {
       throw new DOMException("value could not be cloned", "DataCloneError");
@@ -167,9 +185,13 @@ describe("codapInterface.sendRequest hard timeout", () => {
     await expect(codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" },
                                             callerCallback)).rejects.toThrow(/cloned/);
 
+    expect(callerCallback).toHaveBeenCalledTimes(1);
+    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
+
+    // no deadline was armed, so nothing can fire later against a request that has already settled
     expect(jest.getTimerCount()).toBe(0);
     jest.advanceTimersByTime(kDefaultTimeout);
-    expect(callerCallback).not.toHaveBeenCalled();
+    expect(callerCallback).toHaveBeenCalledTimes(1);
   });
 
   it("clears the deadline once the request has resolved", async () => {
@@ -201,7 +223,7 @@ describe("codapInterface.sendRequest callback contract on failure", () => {
 
     jest.useFakeTimers();
     const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback);
-    const rejection = expect(request).rejects.toMatch(/exceeded/);
+    const rejection = expect(request).rejects.toThrow(/exceeded/);
 
     jest.advanceTimersByTime(kDefaultTimeout);
     await rejection;
@@ -215,10 +237,264 @@ describe("codapInterface.sendRequest callback contract on failure", () => {
     const callerCallback = jest.fn();
 
     await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
-      .rejects.toMatch(/non-existent/);
+      .rejects.toThrow(/non-existent/);
 
     expect(callerCallback).toHaveBeenCalledTimes(1);
     expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
+  });
+
+  it("invokes the callback on a connection that has been destroyed", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+    fresh.destroy();
+
+    const callerCallback = jest.fn();
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
+      .rejects.toThrow(/closed/);
+
+    expect(callerCallback).toHaveBeenCalledTimes(1);
+    expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
+  });
+});
+
+// Two failed review rounds turned on the same question -- is the contract true on *every* path? --
+// answered each time by checking the paths someone had thought of. This enumerates them instead.
+// Every way a request can settle gets one case, and each asserts all three parts of the contract
+// together: how the promise settles, that the callback fires exactly once with the documented
+// argument, and that no deadline is left behind to fire against a settled request.
+describe("codapInterface.sendRequest settles every path through the contract", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    codapInterface.setRequestTimeout(kDefaultTimeout);
+  });
+
+  /** Asserts the parts of the contract that hold no matter how a request settles. */
+  function expectSettledOnce(callerCallback: jest.Mock, response: any) {
+    expect(callerCallback).toHaveBeenCalledTimes(1);
+    expect(callerCallback).toHaveBeenCalledWith(response, expect.anything());
+    expect(jest.getTimerCount()).toBe(0);
+  }
+
+  it("CODAP answers: resolves with the response, callback gets it", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    lastCallback()({ success: true, values: { id: 1 } });
+
+    await expect(request).resolves.toEqual({ success: true, values: { id: 1 } });
+    expectSettledOnce(callerCallback, { success: true, values: { id: 1 } });
+  });
+
+  it("CODAP declines: still resolves, since {success:false} is an answer", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    lastCallback()({ success: false, values: { error: "no such thing" } });
+
+    await expect(request).resolves.toEqual({ success: false, values: { error: "no such thing" } });
+    expectSettledOnce(callerCallback, { success: false, values: { error: "no such thing" } });
+  });
+
+  // The distinction the whole design rests on: iframe-phone's probe is not an outcome, but a reply
+  // of `undefined` from CODAP is -- and it used to be indistinguishable, so it waited out the full
+  // deadline. There is no result to hand back, so it fails rather than resolving with `undefined`.
+  it("CODAP answers with no value: rejects rather than resolving with undefined", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const before = codapInterface.getStats().countDiRplFail;
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    lastCallback()(undefined);          // one argument: a real reply, with no value
+
+    await expect(request).rejects.toThrow(/answered with no result/);
+    expectSettledOnce(callerCallback, undefined);
+    expect(codapInterface.getStats().countDiRplFail).toBe(before + 1);
+  });
+
+  it("the deadline passes: rejects, and says so in the stats", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const before = codapInterface.getStats().countDiReqDeadlineExceeded;
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    const rejection = expect(request).rejects.toThrow(/exceeded/);
+    jest.advanceTimersByTime(kDefaultTimeout);
+    await rejection;
+
+    expectSettledOnce(callerCallback, undefined);
+    expect(codapInterface.getStats().countDiReqDeadlineExceeded).toBe(before + 1);
+  });
+
+  it("the request throws on the way out: rejects with what was thrown", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+    mockCall.mockImplementationOnce(() => {
+      throw new DOMException("value could not be cloned", "DataCloneError");
+    });
+
+    jest.useFakeTimers();
+    await expect(codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                            callerCallback)).rejects.toThrow(/cloned/);
+
+    expectSettledOnce(callerCallback, undefined);
+  });
+
+  it("there is no connection: rejects without waiting", async () => {
+    const fresh = await freshInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
+      .rejects.toThrow(/non-existent/);
+
+    expectSettledOnce(callerCallback, undefined);
+  });
+
+  it("the connection was destroyed: rejects without waiting", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+    fresh.destroy();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback))
+      .rejects.toThrow(/closed/);
+
+    expectSettledOnce(callerCallback, undefined);
+  });
+
+  // Not a settling path: the probe reports that nothing has settled yet, so the contract's
+  // "exactly once" has to mean the callback stays silent here.
+  it("the advisory probe is not an outcome: nothing settles, callback stays silent", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    let settled = false;
+    request.then(() => (settled = true), () => (settled = true));
+
+    advisoryTimeout(lastCallback());
+    await flush();
+
+    expect(settled).toBe(false);
+    expect(callerCallback).not.toHaveBeenCalled();
+
+    lastCallback()({ success: true });     // settle it so no deadline outlives the test
+    await request;
+  });
+
+  // A duplicated reply is a real possibility at the iframe-phone level, and settling once has to
+  // cover the callback as well as the promise.
+  it("a duplicated reply notifies the callback only once", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    const callback = lastCallback();
+    callback({ success: true, values: 1 });
+    callback({ success: true, values: 2 });
+
+    await expect(request).resolves.toEqual({ success: true, values: 1 });
+    expectSettledOnce(callerCallback, { success: true, values: 1 });
+  });
+
+  // A reply can arrive after the deadline has already failed the request. It must not revive it,
+  // report a success against it, or mark a connection the caller has given up on as live.
+  it("a reply after the deadline changes nothing", async () => {
+    jest.useRealTimers();
+    await initInterface();
+    const callerCallback = jest.fn();
+
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               callerCallback);
+    const callback = lastCallback();
+    const rejection = expect(request).rejects.toThrow(/exceeded/);
+    jest.advanceTimersByTime(kDefaultTimeout);
+    await rejection;
+
+    const after = { ...codapInterface.getStats() };
+    callback({ success: true });
+
+    expect(codapInterface.getStats()).toEqual(after);
+    expectSettledOnce(callerCallback, undefined);
+  });
+});
+
+// destroy() reports the state it puts the connection in, so getConnectionState() is honest and new
+// requests are refused. That makes init() responsible for clearing it: without the reset, the
+// handshake below would itself be refused and the connection could never be reestablished.
+describe("codapInterface.destroy", () => {
+  it("reports the connection as closed", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+    expect(fresh.getConnectionState()).toBe("active");
+
+    fresh.destroy();
+
+    expect(fresh.getConnectionState()).toBe("closed");
+  });
+
+  // destroy() does not unsubscribe from iframe-phone, so CODAP can still deliver a notification
+  // afterwards. Handling it must not reopen a connection the caller has closed.
+  it("stays closed when a notification arrives after teardown", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+    fresh.destroy();
+
+    // the handler iframe-phone was constructed with, invoked as a CODAP notification would
+    const notificationHandler = (IframePhoneRpcEndpoint as jest.Mock).mock.calls[0][0];
+    notificationHandler({ action: "notify", resource: "documentChangeNotice", values: {} },
+                        () => undefined);
+
+    expect(fresh.getConnectionState()).toBe("closed");
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
+      .rejects.toThrow(/closed/);
+  });
+
+  it("can be followed by init(), so a plugin can reconnect after teardown", async () => {
+    const fresh = await freshInterface();
+    const firstInit = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await firstInit;
+
+    fresh.destroy();
+
+    const secondInit = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await expect(secondInit).resolves.toBeDefined();
+
+    // and requests work again, rather than being refused by the state destroy() left behind
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
   });
 });
 
@@ -279,7 +555,7 @@ describe("codapInterface.sendRequest callback errors", () => {
     const boom = new Error("callback bug");
 
     await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" },
-                                   () => { throw boom; })).rejects.toMatch(/non-existent/);
+                                   () => { throw boom; })).rejects.toThrow(/non-existent/);
 
     expect(scheduled).toHaveLength(1);
     expect(scheduled[0]).toThrow(boom);
@@ -294,9 +570,9 @@ describe("codapInterface.init handshake", () => {
     const fresh = await freshInterface();
 
     const initPromise = fresh.init({ name: "test", title: "test" } as any);
-    lastCallback()(undefined);          // iframe-phone's 2s advisory timeout, nothing there
+    advisoryTimeout(lastCallback());    // iframe-phone's 2s advisory timeout, nothing there
 
-    await expect(initPromise).rejects.toMatch(/timed out/);
+    await expect(initPromise).rejects.toThrow(/timed out/);
   });
 
   // The fast-fail belongs to the handshake request itself, not to a window of time: an ordinary
@@ -311,7 +587,7 @@ describe("codapInterface.init handshake", () => {
       let settled = false;
       request.then(() => (settled = true), () => (settled = true));
 
-      callbackAt(1)(undefined);   // the ordinary request's advisory timeout
+      advisoryTimeout(callbackAt(1));   // the ordinary request's advisory timeout
       await flush();
 
       expect(settled).toBe(false);
@@ -334,7 +610,7 @@ describe("codapInterface.init handshake", () => {
     request.then(() => (settled = true), () => (settled = true));
 
     const callback = lastCallback();
-    callback(undefined);
+    advisoryTimeout(callback);
     await flush();
 
     expect(settled).toBe(false);
@@ -353,7 +629,7 @@ describe("codapInterface.sendRequest without a connection", () => {
     const fresh = await freshInterface();
 
     await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" }))
-      .rejects.toMatch(/non-existent CODAP connection/);
+      .rejects.toThrow(/non-existent CODAP connection/);
   });
 });
 
@@ -368,7 +644,7 @@ describe("codapInterface stats", () => {
     const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
     const callback = lastCallback();
 
-    callback(undefined);
+    advisoryTimeout(callback);
     await flush();
     expect(fresh.getStats().countDiRplTimeout).toBe(before + 1);
 

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -744,6 +744,30 @@ describe("codapInterface stats", () => {
     expect(fresh.getStats().countDiRplSuccess).toBeGreaterThan(0);
   });
 
+  // A batched request is answered with an array, which has no top-level `success` to read, so every
+  // successful init() handshake used to be counted a decline -- misleading exactly the person reading
+  // getStats() to find out why a plugin is misbehaving.
+  it("counts a batched reply as the one request it was", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    await initPromise;
+
+    expect(fresh.getStats().countDiRplSuccess).toBe(1);
+    expect(fresh.getStats().countDiRplFail).toBe(0);
+    expect(fresh.getStats().countDiReq).toBe(1);
+  });
+
+  it("counts a batched reply as a decline when any part of it failed", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+    lastCallback()([{ success: true }, { success: false, values: { error: "no frame" } }]);
+    await expect(initPromise).rejects.toThrow(/no frame/);
+
+    expect(fresh.getStats().countDiRplSuccess).toBe(0);
+    expect(fresh.getStats().countDiRplFail).toBe(1);
+  });
+
   it("records the time of the first data-interactive request", async () => {
     const fresh = await freshInterface();
     expect(fresh.getStats().timeDiFirstReq).toBeNull();

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -223,7 +223,7 @@ describe("codapInterface.init handshake", () => {
     async () => {
       const fresh = await freshInterface();
 
-      fresh.init({ name: "test", title: "test" } as any).catch(() => undefined);
+      const initPromise = fresh.init({ name: "test", title: "test" } as any);
       const request = fresh.sendRequest({ action: "create", resource: "dataContext[x].item" });
       let settled = false;
       request.then(() => (settled = true), () => (settled = true));
@@ -232,6 +232,11 @@ describe("codapInterface.init handshake", () => {
       await flush();
 
       expect(settled).toBe(false);
+
+      // settle both so neither leaves its deadline timer running past the test
+      callbackAt(0)([{ success: true }, { success: true, values: { savedState: {} } }]);
+      callbackAt(1)({ success: true });
+      await Promise.all([initPromise, request]);
     });
 
   it("does not fail fast once the connection is established", async () => {
@@ -245,10 +250,15 @@ describe("codapInterface.init handshake", () => {
     const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
     request.then(() => (settled = true), () => (settled = true));
 
-    lastCallback()(undefined);
+    const callback = lastCallback();
+    callback(undefined);
     await flush();
 
     expect(settled).toBe(false);
+
+    // settle it so its deadline timer doesn't outlive the test
+    callback({ success: true });
+    await request;
   });
 });
 

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -518,6 +518,27 @@ describe("codapInterface.init", () => {
     await expect(request).resolves.toEqual({ success: true });
   });
 
+  // The case the two-second guess exists to serve, and the one it can get wrong: a CODAP that was
+  // there all along, just slow to finish iframe-phone's hello exchange. Its answer arrives after the
+  // connection has been closed for silence, and evidence outranks silence whenever it arrives, so
+  // the answer reopens the connection rather than being discarded for being late.
+  it("reopens a connection closed for silence when CODAP answers after all", async () => {
+    const fresh = await freshInterface();
+    const initPromise = fresh.init({ name: "test", title: "test" } as any);
+
+    advisoryTimeout(lastCallback());
+    await expect(initPromise).rejects.toThrow(/timed out/);
+    expect(fresh.getConnectionState()).toBe("closed");
+
+    // iframe-phone keeps the callback after its advisory timer fires, so the real reply still lands
+    lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+    expect(fresh.getConnectionState()).toBe("active");
+
+    const request = fresh.sendRequest({ action: "get", resource: "dataContext[x]" });
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+  });
+
   // A reply is not the only thing that proves CODAP is there. A notification arrives on the same
   // channel and marks the connection active by a different route, so it counts as evidence too.
   it("keeps a connection CODAP sent a notification on during the handshake", async () => {

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -1,0 +1,133 @@
+import { codapInterface } from "./codap-interface";
+
+// iframe-phone invokes the callback passed to `call()` with `undefined` when its hard-coded 2s
+// timer expires, but it does NOT cancel the request or forget the callback — when CODAP finally
+// replies it invokes the same callback a second time with the real value. These tests capture
+// that callback so both invocations can be simulated.
+const mockCall = jest.fn();
+
+jest.mock("iframe-phone", () => ({
+  IframePhoneRpcEndpoint: jest.fn().mockImplementation(() => ({
+    call: (message: any, callback: (response: any) => void) => mockCall(message, callback)
+  }))
+}));
+
+/** The callback iframe-phone would hold for the most recent request. */
+function lastCallback(): (response: any) => void {
+  return mockCall.mock.calls[mockCall.mock.calls.length - 1][1];
+}
+
+/** Resolves after pending microtasks flush, so promise settlement can be observed. */
+function flush() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function initInterface() {
+  mockCall.mockClear();
+  const initPromise = codapInterface.init({ name: "test", title: "test" } as any);
+  // satisfy the [updateFrame, getFrame] handshake
+  lastCallback()([{ success: true }, { success: true, values: { savedState: {} } }]);
+  await initPromise;
+  mockCall.mockClear();
+}
+
+describe("codapInterface.sendRequest", () => {
+  beforeEach(async () => {
+    jest.useRealTimers();
+    await initInterface();
+  });
+
+  it("does not settle when iframe-phone reports its advisory timeout", async () => {
+    let settled = false;
+    const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
+    request.then(() => (settled = true), () => (settled = true));
+
+    // iframe-phone's 2s timer fires: callback invoked with undefined
+    lastCallback()(undefined);
+    await flush();
+
+    expect(settled).toBe(false);
+  });
+
+  it("resolves with the real response when it arrives after the advisory timeout", async () => {
+    const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
+    const callback = lastCallback();
+
+    callback(undefined);              // advisory timeout
+    await flush();
+    callback({ success: true, values: { itemIDs: ["a", "b"] } });   // CODAP finally replies
+
+    await expect(request).resolves.toEqual({ success: true, values: { itemIDs: ["a", "b"] } });
+  });
+
+  it("does not invoke the caller's callback with undefined on the advisory timeout", async () => {
+    const callerCallback = jest.fn();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" }, callerCallback);
+    const callback = lastCallback();
+
+    callback(undefined);
+    await flush();
+    expect(callerCallback).not.toHaveBeenCalled();
+
+    callback({ success: true });
+    await request;
+    expect(callerCallback).toHaveBeenCalledTimes(1);
+    expect(callerCallback).toHaveBeenCalledWith({ success: true }, expect.anything());
+  });
+
+  it("still resolves only once when the real reply arrives twice", async () => {
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
+    const callback = lastCallback();
+
+    callback({ success: true, values: 1 });
+    callback({ success: true, values: 2 });
+
+    await expect(request).resolves.toEqual({ success: true, values: 1 });
+  });
+});
+
+describe("codapInterface.sendRequest hard timeout", () => {
+  beforeEach(async () => {
+    jest.useRealTimers();
+    await initInterface();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    codapInterface.setRequestTimeout(60000);
+  });
+
+  it("rejects if no real reply ever arrives, so a dead CODAP cannot hang the caller forever",
+    async () => {
+      jest.useFakeTimers();
+      const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
+      const rejection = expect(request).rejects.toMatch(/exceeded/);
+
+      lastCallback()(undefined);        // advisory timeout — must not settle
+      jest.advanceTimersByTime(60000);  // hard deadline elapses
+
+      await rejection;
+    });
+
+  it("uses a configurable hard timeout", async () => {
+    codapInterface.setRequestTimeout(5000);
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" });
+    const rejection = expect(request).rejects.toMatch(/exceeded/);
+
+    jest.advanceTimersByTime(5000);
+
+    await rejection;
+  });
+
+  it("does not reject after the hard deadline once the request has resolved", async () => {
+    jest.useFakeTimers();
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
+
+    lastCallback()({ success: true });
+    await expect(request).resolves.toEqual({ success: true });
+
+    // advancing past the deadline must not produce an unhandled rejection
+    expect(() => jest.advanceTimersByTime(120000)).not.toThrow();
+  });
+});

--- a/src/api/codap-interface.spec.ts
+++ b/src/api/codap-interface.spec.ts
@@ -153,6 +153,25 @@ describe("codapInterface.sendRequest hard timeout", () => {
       await rejection;
     });
 
+  // `connection.call` can throw synchronously -- an uncloneable value in the message makes
+  // postMessage raise DataCloneError -- and that rejects the promise directly, without going
+  // through settle(). A deadline armed before the call would survive that and fire a minute later,
+  // reporting a failure the caller had already handled.
+  it("leaves no deadline behind when the request throws synchronously", async () => {
+    const callerCallback = jest.fn();
+    mockCall.mockImplementationOnce(() => {
+      throw new DOMException("value could not be cloned", "DataCloneError");
+    });
+
+    jest.useFakeTimers();
+    await expect(codapInterface.sendRequest({ action: "create", resource: "dataContext[x].item" },
+                                            callerCallback)).rejects.toThrow(/cloned/);
+
+    expect(jest.getTimerCount()).toBe(0);
+    jest.advanceTimersByTime(kDefaultTimeout);
+    expect(callerCallback).not.toHaveBeenCalled();
+  });
+
   it("clears the deadline once the request has resolved", async () => {
     jest.useFakeTimers();
     const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" });
@@ -200,6 +219,70 @@ describe("codapInterface.sendRequest callback contract on failure", () => {
 
     expect(callerCallback).toHaveBeenCalledTimes(1);
     expect(callerCallback).toHaveBeenCalledWith(undefined, expect.anything());
+  });
+});
+
+// A throw from the caller's callback is a consumer bug, not a failure of the request -- which has
+// already settled by then. It must not escape into the stack that invoked the callback (iframe-
+// phone's listener, the deadline timer, this executor), so it is rethrown on a fresh task, where it
+// stays an uncaught error that window.onerror and error reporters can see. These tests capture what
+// is scheduled rather than letting it throw, which would fail the suite it is meant to be reported
+// through.
+describe("codapInterface.sendRequest callback errors", () => {
+  let scheduled: Array<() => void>;
+  let queueMicrotaskSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    jest.useRealTimers();
+    await initInterface();
+    scheduled = [];
+    queueMicrotaskSpy = jest.spyOn(window, "queueMicrotask")
+        .mockImplementation((thunk: () => void) => { scheduled.push(thunk); });
+  });
+
+  // restore only this spy: jest.restoreAllMocks() would also reset the iframe-phone module mock
+  afterEach(() => {
+    queueMicrotaskSpy.mockRestore();
+  });
+
+  it("rethrows what a callback throws, without failing the request", async () => {
+    const boom = new Error("callback bug");
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               () => { throw boom; });
+
+    lastCallback()({ success: true });
+
+    await expect(request).resolves.toEqual({ success: true });
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toThrow(boom);
+  });
+
+  // An async callback turns its throw into a rejected return value, which a try/catch around the
+  // call never sees.
+  it("rethrows what an async callback throws", async () => {
+    const boom = new Error("async callback bug");
+    const request = codapInterface.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                               async () => { throw boom; });
+
+    lastCallback()({ success: true });
+
+    await expect(request).resolves.toEqual({ success: true });
+    await flush();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toThrow(boom);
+  });
+
+  // Nothing ever calls back on this path, so the callback runs on the executor's own stack -- where
+  // a throw would be swallowed by the Promise machinery, the request having already rejected.
+  it("rethrows a callback throw on the no-connection path", async () => {
+    const fresh = await freshInterface();
+    const boom = new Error("callback bug");
+
+    await expect(fresh.sendRequest({ action: "get", resource: "dataContext[x]" },
+                                   () => { throw boom; })).rejects.toMatch(/non-existent/);
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toThrow(boom);
   });
 });
 

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -159,14 +159,24 @@ export type ClientHandler = (notification: ClientNotification) => void;
  * satisfy it, and will not compile — which is the intent, because such a callback throws a
  * `TypeError` the first time a request fails, on a path a plugin may not exercise until it is in
  * front of users.
- *
- * A batched request — an array of requests — is answered with an array of results. That does not fit
- * here, so batch through the returned promise rather than a callback.
  */
 export type RequestCallback = (response?: IResult, request?: any) => void;
 
+/**
+ * As `RequestCallback`, for a batched request: CODAP answers an array of requests with an array of
+ * results. `sendRequest` requires this shape when the message is an array and rejects it otherwise,
+ * so a callback cannot be paired with a response it is unable to read.
+ */
+export type BatchRequestCallback = (response?: IResult[], request?: any) => void;
+
 /** What CODAP answers with: one result, or one per request when a batch was sent. */
 type CodapResponse = IResult | IResult[];
+
+/**
+ * Either callback shape. `sendRequest` decides which one a caller may pass from the shape of their
+ * message, so the request path itself holds both and does not care which it has.
+ */
+type EitherRequestCallback = RequestCallback | BatchRequestCallback;
 
 let interactiveState = {};
 
@@ -255,7 +265,7 @@ interface IRequestOptions {
    * JSDoc carries this contract for consumers — this interface is module-private and never reaches
    * the published type declarations.
    */
-  callback?: RequestCallback
+  callback?: EitherRequestCallback
   /**
    * Reject as soon as iframe-phone reports no reply, instead of waiting out `requestTimeout`.
    *
@@ -365,13 +375,18 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
         // see reportCallbackError.
         try {
           // An async callback reports a throw as a rejected return value, which the catch can't see.
-          // `RequestCallback` returns `void`, but TypeScript lets a callback in that position return
+          // The callback types return `void`, but TypeScript lets a callback in that position return
           // a value anyway, so an async one arrives here as a promise and has to be observed.
-          // A batched request's callback receives the array, which `RequestCallback` does not
-          // describe — see its doc: batch through the promise. The cast keeps that documented
-          // narrowing here rather than pushing an array every consumer must handle into the type.
-          const callbackResult = callback(callbackResponse as IResult | undefined,
-                                          message) as unknown;
+          //
+          // The response is handed over unnarrowed: `sendRequest` pairs the callback's shape with the
+          // message's, so a batched request's callback is the one that takes an array and a single
+          // request's is the one that takes a result. This code does not need to know which it has.
+          // Calling the union directly would demand an argument satisfying both signatures at once,
+          // which only `undefined` does. Narrowing it to one accepting either response says what is
+          // actually true: `sendRequest` admits only the callback that matches its message's shape,
+          // so whichever is here can read whatever CODAP sent for it.
+          const notify = callback as (response?: CodapResponse, request?: any) => void;
+          const callbackResult = notify(callbackResponse, message) as unknown;
           if (callbackResult && typeof (callbackResult as PromiseLike<unknown>).then === "function") {
             (callbackResult as PromiseLike<unknown>).then(undefined, reportCallbackError);
           }
@@ -712,7 +727,9 @@ export const codapInterface = {
    *
    * @return {Promise} The promise of the response from CODAP.
    */
-  sendRequest (message: any, callback?: RequestCallback) {
+  sendRequest <TMessage>(message: TMessage,
+                         callback?: TMessage extends readonly any[] ? BatchRequestCallback
+                                                                    : RequestCallback) {
     return issueRequest(message, { callback });
   },
 

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -165,6 +165,9 @@ export type ClientHandler = (notification: ClientNotification) => void;
  */
 export type RequestCallback = (response?: IResult, request?: any) => void;
 
+/** What CODAP answers with: one result, or one per request when a batch was sent. */
+type CodapResponse = IResult | IResult[];
+
 let interactiveState = {};
 
 /**
@@ -351,7 +354,7 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
     // optional callback argument: what the callback receives is then fixed by which one is called,
     // so a path added later cannot resolve the promise correctly while notifying its callback with
     // `undefined`.
-    function settle (settleFn: (value?: any) => void, value: any, callbackResponse?: IResult) {
+    function settle (settleFn: (value?: any) => void, value: any, callbackResponse?: CodapResponse) {
       if (isSettled) { return; }
       isSettled = true;
       if (timeoutTimer !== undefined) { clearTimeout(timeoutTimer); }
@@ -364,7 +367,11 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
           // An async callback reports a throw as a rejected return value, which the catch can't see.
           // `RequestCallback` returns `void`, but TypeScript lets a callback in that position return
           // a value anyway, so an async one arrives here as a promise and has to be observed.
-          const callbackResult = callback(callbackResponse, message) as unknown;
+          // A batched request's callback receives the array, which `RequestCallback` does not
+          // describe — see its doc: batch through the promise. The cast keeps that documented
+          // narrowing here rather than pushing an array every consumer must handle into the type.
+          const callbackResult = callback(callbackResponse as IResult | undefined,
+                                          message) as unknown;
           if (callbackResult && typeof (callbackResult as PromiseLike<unknown>).then === "function") {
             (callbackResult as PromiseLike<unknown>).then(undefined, reportCallbackError);
           }
@@ -374,7 +381,7 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
       }
     }
 
-    function settleSuccess (response: IResult) {
+    function settleSuccess (response: CodapResponse) {
       settle(resolve, response, response);
     }
 
@@ -400,7 +407,7 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
      *    CODAP arrives as `undefined` with this argument absent, which is a real answer and settles
      *    the request at once. See `connection`'s type for why this argument has to be declared.
      */
-    function handleResponse (response: IResult | undefined | null, noReplyYet?: Error) {
+    function handleResponse (response: CodapResponse | undefined | null, noReplyYet?: Error) {
       // A reply can still arrive after the deadline rejected the request. Returning early keeps it
       // from marking the connection active or counting a success against a request the caller has
       // already been told failed.
@@ -427,10 +434,15 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
         return;
       }
       markConnectionActive();
-      // TODO: a batched request is answered with an array, which has no top-level `success`, so
-      // every successful init() handshake is counted a decline here. These counters are diagnostic
-      // only, but they mislead whoever reads getStats() to find out why a plugin is misbehaving.
-      if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
+      // A batched request — an array of requests — is answered with an array of results, which has no
+      // top-level `success` to read. It counts as the one request it was, and as a success only if
+      // every result in it succeeded, so the counters keep reconciling against `countDiReq`. A reply
+      // with no results in it counts as a decline rather than a vacuous success, since a batch
+      // answered by nothing did not do what was asked.
+      const succeeded = Array.isArray(response)
+                          ? response.length > 0 && response.every(result => result?.success)
+                          : response.success;
+      if (succeeded) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
       settleSuccess(response);
     }
 

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -80,9 +80,24 @@ const kMaxRequestTimeout = 2 ** 31 - 1;
 let requestTimeout = kDefaultRequestTimeout;
 
 const stats = {
+  /** How many requests were sent to CODAP. */
   countDiReq: 0,
+  /** How many requests CODAP answered with `{success: true}`. */
   countDiRplSuccess: 0,
+  /**
+   * How many requests CODAP answered with `{success: false}` — that is, answered and declined.
+   * These are outcomes, not failures: the request's promise resolves with the response. For
+   * requests that failed, see `countDiReqFailed`.
+   */
   countDiRplFail: 0,
+  /**
+   * How many requests failed, and so rejected: no connection to send on, no answer within the
+   * deadline, an answer carrying no result, or the send itself throwing.
+   *
+   * `countDiReq - countDiRplSuccess - countDiRplFail - countDiReqFailed` is the number still in
+   * flight. `countDiReqDeadlineExceeded` counts the subset that ran out of time.
+   */
+  countDiReqFailed: 0,
   /**
    * How many times iframe-phone's advisory 2s timer has reported that no reply has arrived yet.
    *
@@ -91,7 +106,10 @@ const stats = {
    * wrong. For requests that actually ran out of time, see `countDiReqDeadlineExceeded`.
    */
   countDiRplTimeout: 0,
-  /** How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. */
+  /**
+   * How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. A subset
+   * of `countDiReqFailed`.
+   */
   countDiReqDeadlineExceeded: 0,
   countCodapReq: 0,
   countCodapUnhandledReq: 0,
@@ -142,6 +160,9 @@ let interactiveState = {};
  */
 const notificationSubscribers: { actionSpec: string; resourceSpec: any; operation: any; handler: any; }[] = [];
 
+/** Whether init() has already registered its default interactiveState handler. */
+let interactiveStateHandlerRegistered = false;
+
 function matchResource(resourceName: any, resourceSpec: string) {
   return resourceSpec === "*" || resourceName === resourceSpec;
 }
@@ -152,12 +173,7 @@ function notificationHandler (request: { action: any; resource: any; values: any
   let requestValues = request.values;
   let returnMessage = {success: true};
 
-  // CODAP is talking to us, so the connection is live — unless we have torn it down, in which case
-  // a notification still arriving (destroy() does not unsubscribe from iframe-phone) must not
-  // reopen a connection the caller has closed.
-  if (connection) {
-    connectionState = "active";
-  }
+  markConnectionActive();
   stats.countCodapReq += 1;
   stats.timeCodapLastReq = new Date();
   if (!stats.timeCodapFirstReq) {
@@ -233,11 +249,16 @@ interface IRequestOptions {
   /**
    * Reject as soon as iframe-phone reports no reply, instead of waiting out `requestTimeout`.
    *
-   * Set only for the handshake in `init()`. Everywhere else a request that draws no reply within
-   * iframe-phone's advisory 2s is assumed to be in flight and still coming; during the handshake
-   * there is no such assumption to make, so silence means nothing is listening. This is a property
-   * of the individual request rather than of the connection state, so an ordinary request issued
-   * while the handshake is outstanding is still treated as an ordinary request.
+   * Set only for the handshake in `init()`, and a deliberate trade rather than a safe inference.
+   * Silence at 2s does not prove nothing is listening: iframe-phone buffers into `postMessageQueue`
+   * until the parent answers its repeated "hello", while the 2s probe is armed when `call` is
+   * invoked — so a parent slow to complete that exchange looks the same as no parent at all. We
+   * accept that, because the alternative is a plugin loaded outside CODAP hanging for the full
+   * request timeout before it can say so, and because a plugin that does load in CODAP can retry.
+   *
+   * This is a property of the individual request rather than of the connection state, so an
+   * ordinary request issued while the handshake is outstanding is still treated as an ordinary
+   * request.
    */
   failFastWithoutReply?: boolean
 }
@@ -255,6 +276,34 @@ interface IRequestOptions {
  */
 function reportCallbackError (error: unknown) {
   queueMicrotask(() => { throw error; });
+}
+
+/**
+ * Renders a request for inclusion in an error message.
+ *
+ * `JSON.stringify` throws on a cyclic value and on a BigInt, both of which `postMessage` accepts —
+ * so a request carrying either is genuinely sent, and the only thing that fails is describing it.
+ * Building a failure message from `JSON.stringify` unguarded would therefore throw while a request
+ * was being failed, leaving it settled by nothing at all.
+ */
+function describeMessage (message: unknown) {
+  try {
+    return JSON.stringify(message) ?? String(message);
+  } catch {
+    return "[message could not be serialized]";
+  }
+}
+
+/**
+ * Records that CODAP is talking to us — unless the caller has torn the connection down, in which
+ * case traffic still arriving must not reopen a connection they closed. `destroy()` does not
+ * unsubscribe from iframe-phone, and a reply to a request that was already in flight can arrive
+ * after it, so both this module's inbound paths have to check.
+ */
+function markConnectionActive () {
+  if (connection) {
+    connectionState = "active";
+  }
 }
 
 /**
@@ -305,8 +354,12 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
      * stack, and so every rejection from this module has one shape to handle. Takes `unknown` so
      * that a caught exception can be passed straight through without each call site repeating the
      * same normalization.
+     *
+     * Every failure goes through here, which is what lets `countDiReqFailed` account for all of
+     * them without each path remembering to count itself.
      */
     function settleFailure (reason: unknown) {
+      if (!isSettled) { stats.countDiReqFailed++; }
       settle(reject, reason instanceof Error ? reason : new Error(String(reason)));
     }
 
@@ -318,33 +371,35 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
      *    CODAP arrives as `undefined` with this argument absent, which is a real answer and settles
      *    the request at once. See `connection`'s type for why this argument has to be declared.
      */
-    function handleResponse (response: IResult | undefined, noReplyYet?: Error) {
+    function handleResponse (response: IResult | undefined | null, noReplyYet?: Error) {
       // A reply can still arrive after the deadline rejected the request. Returning early keeps it
       // from marking the connection active or counting a success against a request the caller has
       // already been told failed.
       if (isSettled) { return; }
 
-      if (response === undefined) {
+      // `null` is grouped with `undefined` deliberately: it is just as empty an answer, and reading
+      // `.success` off it would throw here, inside iframe-phone's message listener, where nothing
+      // would settle the request.
+      if (response === undefined || response === null) {
         if (noReplyYet) {
           // Nothing has answered within iframe-phone's advisory 2s. The request is still in flight,
           // so this is not an outcome — except during the handshake, where silence is the answer.
           stats.countDiRplTimeout++;
           if (failFastWithoutReply) {
-            settleFailure("handleResponse: CODAP request timed out: " + JSON.stringify(message));
+            settleFailure("handleResponse: CODAP request timed out: " + describeMessage(message));
           }
           return;
         }
         // CODAP answered, with no value. That is a real answer and settles the request, but there
         // is no result for the caller to read, so it fails rather than resolving with `undefined`
         // and handing the caller something `result.success` throws on.
-        connectionState = "active";
-        stats.countDiRplFail++;
-        settleFailure("handleResponse: CODAP answered with no result: " + JSON.stringify(message));
+        markConnectionActive();
+        settleFailure("handleResponse: CODAP answered with no result: " + describeMessage(message));
         return;
       }
-      connectionState = "active";
+      markConnectionActive();
       // TODO: a batched request is answered with an array, which has no top-level `success`, so
-      // every successful init() handshake is counted a failure here. These counters are diagnostic
+      // every successful init() handshake is counted a decline here. These counters are diagnostic
       // only, but they mislead whoever reads getStats() to find out why a plugin is misbehaving.
       if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
       settleSuccess(response);
@@ -353,7 +408,7 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
     switch (connectionState) {
       case "closed": // log the message and ignore
         // console.warn('sendRequest on closed CODAP connection: ' + JSON.stringify(message));
-        settleFailure("sendRequest on closed CODAP connection: " + JSON.stringify(message));
+        settleFailure("sendRequest on closed CODAP connection: " + describeMessage(message));
         break;
       case "preinit": // warn, but issue request.
         // console.log('sendRequest on not yet initialized CODAP connection: ' +
@@ -393,12 +448,12 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
           timeoutTimer = setTimeout(function () {
             stats.countDiReqDeadlineExceeded++;
             settleFailure("sendRequest: CODAP request exceeded " + timeout + "ms: " +
-                JSON.stringify(message));
+                describeMessage(message));
           }, timeout);
         } else {
           // Nothing will ever call back, so settle now rather than leaving the caller waiting
           // forever — the same guarantee the deadline provides once a request is in flight.
-          settleFailure("sendRequest on non-existent CODAP connection: " + JSON.stringify(message));
+          settleFailure("sendRequest on non-existent CODAP connection: " + describeMessage(message));
         }
     }
   });
@@ -426,7 +481,28 @@ export const codapInterface = {
   init (iConfig: IConfig, iCallback?: (arg0: any) => void) {
     const this_ = this;
     return new Promise(function (resolve: (arg0: any) => void, reject: { (arg0: string): void; (arg0: any): void; }) {
+      /**
+       * Fails the handshake, and with it the connection.
+       *
+       * A handshake that got no answer leaves a `connection` object that nothing is listening to.
+       * Left in place it looks live to `issueRequest`, so every later request would be sent and then
+       * wait out the full deadline — a minute per request for a plugin that has already been told it
+       * is not running inside CODAP. Tearing it down means those requests are refused at once,
+       * which is what `init()` rejecting is supposed to have told the caller.
+       */
+      function failHandshake(reason: unknown) {
+        connection = null;
+        connectionState = "closed";
+        reject(reason instanceof Error ? reason : new Error(String(reason)));
+        // the callback reports every outcome, as sendRequest's does; there is no state to pass on
+        if (iCallback) {
+          iCallback(undefined);
+        }
+      }
+
       function getFrameRespHandler(resp: { values: { error: any; savedState: any }; success: boolean }[]) {
+        // `resp` is always defined here: a handshake that drew no reply rejects rather than
+        // resolving, so it reaches failHandshake instead of this function.
         const success = resp && resp[1] && resp[1].success;
         const receivedFrame = success && resp[1].values;
         const savedState = receivedFrame && receivedFrame.savedState;
@@ -437,17 +513,11 @@ export const codapInterface = {
             iConfig.stateHandler(savedState);
           }
           resolve(savedState);
-        } else {
-          if (!resp) {
-            reject("Connection request to CODAP timed out.");
-          } else {
-            reject(
-                (resp[1] && resp[1].values && resp[1].values.error) ||
-                "unknown failure");
+          if (iCallback) {
+            iCallback(savedState);
           }
-        }
-        if (iCallback) {
-          iCallback(savedState);
+        } else {
+          failHandshake((resp[1] && resp[1].values && resp[1].values.error) || "unknown failure");
         }
       }
 
@@ -476,16 +546,19 @@ export const codapInterface = {
       // connection could never be reestablished.
       connectionState = "preinit";
 
-      if (!config.customInteractiveStateHandler) {
+      // guard against re-registering on a second init(), which would leave a duplicate subscriber
+      // behind for every reconnect
+      if (!config.customInteractiveStateHandler && !interactiveStateHandlerRegistered) {
         this_.on("get", "interactiveState", function () {
           return ({success: true, values: this_.getInteractiveState()});
         }.bind(this_));
+        interactiveStateHandlerRegistered = true;
       }
 
       // console.log('sending interactiveState: ' + JSON.stringify(this_.getInteractiveState));
       // update, then get the interactiveFrame.
       return issueRequest([updateFrameReq, getFrameReq], { failFastWithoutReply: true })
-        .then(getFrameRespHandler as any, reject);
+        .then(getFrameRespHandler as any, failHandshake);
     }.bind(this));
   },
 
@@ -554,11 +627,21 @@ export const codapInterface = {
    * `init()` can be called again to reconnect.
    */
   destroy () {
-    // TODO: settle the requests still in flight. Each of them waits out its full deadline instead —
-    // a minute in which the caller holds its payload alive after the plugin is gone, ending in a
-    // rejection that can surface against a re-initialized instance. They used to fail within
-    // iframe-phone's ~2s by accident. Settling them needs a registry of in-flight requests, since
-    // `isSettled` and `timeoutTimer` are locals inside each issueRequest executor.
+    // TODO: tear down properly. Two things are missing, and both need machinery this does not have.
+    //
+    // Settle the requests still in flight: each waits out its full deadline instead — a minute in
+    // which the caller holds its payload alive after the plugin is gone, ending in a rejection that
+    // can surface against a re-initialized instance. They used to fail within iframe-phone's ~2s by
+    // accident. Doing it needs a registry of in-flight requests, since `isSettled` and
+    // `timeoutTimer` are locals inside each issueRequest executor.
+    //
+    // Unsubscribe from iframe-phone, whose endpoint exposes `disconnect()`: dropping the reference
+    // leaves its window message listener installed, so CODAP's notifications still reach
+    // notificationHandler after teardown (which is why the inbound paths check `connection` before
+    // reporting the connection live) and a reply to a request still in flight is delivered to a
+    // callback for a request nobody is waiting on. Calling it needs coverage of what iframe-phone's
+    // module-level endpoint singleton does across a disconnect/reconnect, which these unit tests
+    // cannot provide against a mocked endpoint.
     connection = null;
     // Report the state the caller put us in, so getConnectionState() is honest after teardown and
     // new requests are refused rather than reaching a null connection. init() resets this.

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -295,6 +295,26 @@ function describeMessage (message: unknown) {
 }
 
 /**
+ * Invokes one of `init()`'s optional callbacks, keeping what it throws out of the handshake.
+ *
+ * Same reasoning as `reportCallbackError`, which it delegates to: by the time these run the
+ * handshake has settled, so a throw from one is the caller's bug rather than a failure to connect,
+ * and it must not escape into the promise chain the handshake is resolved from — where nothing
+ * observes it, so it would be invisible.
+ */
+function notifyInitCallback (callback: ((state: any) => void) | undefined, state: any) {
+  if (!callback) { return; }
+  try {
+    const result = callback(state) as unknown;
+    if (result && typeof (result as PromiseLike<unknown>).then === "function") {
+      (result as PromiseLike<unknown>).then(undefined, reportCallbackError);
+    }
+  } catch (error) {
+    reportCallbackError(error);
+  }
+}
+
+/**
  * Records that CODAP is talking to us — unless the caller has torn the connection down, in which
  * case traffic still arriving must not reopen a connection they closed. `destroy()` does not
  * unsubscribe from iframe-phone, and a reply to a request that was already in flight can arrive
@@ -422,34 +442,30 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
             stats.timeDiFirstReq = stats.timeDiLastReq;
           }
 
-          // Issue the request before arming the deadline, and settle if it throws. `call` can throw
-          // synchronously — an uncloneable value in the message makes postMessage raise
-          // DataCloneError. Settling here rather than letting the throw escape the executor is what
-          // keeps the callback contract true on this path: an escaped throw rejects the promise
+          // `call` can throw synchronously — an uncloneable value in the message makes postMessage
+          // raise DataCloneError. Settling here rather than letting the throw escape the executor is
+          // what keeps the callback contract true on this path: an escaped throw rejects the promise
           // without ever passing through settle(), so the caller's callback would never fire.
           //
-          // Two things this ordering buys, both load-bearing. Arming the deadline first would leave
-          // the timer live after such a throw, to fire a spurious failure a minute later. And
-          // `break` here is what keeps that from happening now: without it control would fall
-          // through and arm a deadline on a request that has already settled.
-          //
-          // Nothing can settle before the timer exists, because iframe-phone never invokes the
-          // callback synchronously — it stores the callback, arms its own 2s timer, then posts.
+          // The deadline is armed inside the same `try`, after the call, so a throw skips it: there
+          // is then no timer to outlive a request that has already settled, and no ordering for a
+          // later edit to get wrong. Nothing can settle before the timer exists, because iframe-phone
+          // never invokes the callback synchronously — it stores the callback, arms its own 2s timer,
+          // and posts.
           try {
             connection.call(message, handleResponse);
+
+            // Capture the deadline this request was given, so a later setRequestTimeout() can't
+            // make the reported duration disagree with the timer that actually fired.
+            const timeout = requestTimeout;
+            timeoutTimer = setTimeout(function () {
+              stats.countDiReqDeadlineExceeded++;
+              settleFailure("sendRequest: CODAP request exceeded " + timeout + "ms: " +
+                  describeMessage(message));
+            }, timeout);
           } catch (error) {
             settleFailure(error);
-            break;
           }
-
-          // Capture the deadline this request was given, so a later setRequestTimeout() can't
-          // make the reported duration disagree with the timer that actually fired.
-          const timeout = requestTimeout;
-          timeoutTimer = setTimeout(function () {
-            stats.countDiReqDeadlineExceeded++;
-            settleFailure("sendRequest: CODAP request exceeded " + timeout + "ms: " +
-                describeMessage(message));
-          }, timeout);
         } else {
           // Nothing will ever call back, so settle now rather than leaving the caller waiting
           // forever — the same guarantee the deadline provides once a request is in flight.
@@ -495,9 +511,7 @@ export const codapInterface = {
         connectionState = "closed";
         reject(reason instanceof Error ? reason : new Error(String(reason)));
         // the callback reports every outcome, as sendRequest's does; there is no state to pass on
-        if (iCallback) {
-          iCallback(undefined);
-        }
+        notifyInitCallback(iCallback, undefined);
       }
 
       function getFrameRespHandler(resp: { values: { error: any; savedState: any }; success: boolean }[]) {
@@ -508,14 +522,14 @@ export const codapInterface = {
         const savedState = receivedFrame && receivedFrame.savedState;
         this_.updateInteractiveState(savedState);
         if (success) {
-          // deprecated way of conveying state
-          if (iConfig.stateHandler) {
-            iConfig.stateHandler(savedState);
-          }
+          // Settle before handing control to the caller's handlers, and keep what they throw out of
+          // this promise — the same contract sendRequest's callback has, for the same reason. Called
+          // the other way round, a stateHandler that threw would leave init() unsettled forever and
+          // its exception discarded, because nothing observes the promise this handler returns into.
           resolve(savedState);
-          if (iCallback) {
-            iCallback(savedState);
-          }
+          // deprecated way of conveying state
+          notifyInitCallback(iConfig.stateHandler, savedState);
+          notifyInitCallback(iCallback, savedState);
         } else {
           failHandshake((resp[1] && resp[1].values && resp[1].values.error) || "unknown failure");
         }
@@ -659,8 +673,9 @@ export const codapInterface = {
    *   includes `{success: false}`, which means CODAP answered and declined — a resolved promise, not
    *   a rejected one.
    * - **The request failed:** the promise rejects with an `Error` and the callback is invoked with
-   *   `undefined`. This covers exceeding the deadline, there being no connection to send on (before
-   *   `initializePlugin()` or after `destroy()`), and CODAP answering with no value at all.
+   *   `undefined`. Every way a request can fail reports this way — exceeding the deadline, there
+   *   being no connection to send on (before `initializePlugin()` or after `destroy()`), CODAP
+   *   answering with no value at all, and the send itself throwing.
    *
    * The callback is invoked exactly once, after the promise has settled. A callback written as
    * `result.success` therefore has to handle the `undefined` it receives on failure. Note that the

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -338,17 +338,19 @@ function describeMessage (message: unknown) {
 }
 
 /**
- * Invokes one of `init()`'s optional callbacks, keeping what it throws out of the handshake.
+ * Runs one of the steps `init()` takes after its handshake has settled, keeping what that step
+ * throws out of the handshake.
  *
- * Same reasoning as `reportCallbackError`, which it delegates to: by the time these run the
- * handshake has settled, so a throw from one is the caller's bug rather than a failure to connect,
- * and it must not escape into the promise chain the handshake is resolved from — where nothing
- * observes it, so it would be invisible.
+ * Used both for the caller's own callbacks and for this module's merge of the saved state, which is
+ * why it is not named for either: by the time any of them runs the handshake has settled, so a throw
+ * is not a failure to connect, and it must not escape into the promise chain the handshake was
+ * resolved from — where nothing observes it, and it would be invisible. Reported through
+ * `reportCallbackError`, so an uncaught error reaches `window.onerror` either way.
  */
-function notifyInitCallback (callback: ((state: any) => void) | undefined, state: any) {
-  if (!callback) { return; }
+function afterHandshake (step: ((state: any) => void) | undefined, state: any) {
+  if (!step) { return; }
   try {
-    const result = callback(state) as unknown;
+    const result = step(state) as unknown;
     if (result && typeof (result as PromiseLike<unknown>).then === "function") {
       (result as PromiseLike<unknown>).then(undefined, reportCallbackError);
     }
@@ -460,8 +462,15 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
           // so this is not an outcome — except during the handshake, where silence is the answer.
           stats.countDiRplTimeout++;
           if (onSilence) {
-            onSilence();
-            settleFailure("handleResponse: CODAP request timed out: " + describeMessage(message));
+            // `finally`, because this runs inside iframe-phone's message listener: a throw from a
+            // supplied function must not leave the request unsettled and escape into that listener,
+            // which is the failure this module exists to prevent. Every other consumer-supplied
+            // function here is guarded the same way.
+            try {
+              onSilence();
+            } finally {
+              settleFailure("handleResponse: CODAP request timed out: " + describeMessage(message));
+            }
           }
           return;
         }
@@ -559,10 +568,26 @@ export const codapInterface = {
    * Update interactive frame to set name and dimensions and other configuration
    * information.
    *
+   * Resolves with the interactive state CODAP had saved for this plugin, or rejects with an `Error`
+   * if the handshake does not succeed. The callback is invoked either way, as `sendRequest`'s is:
+   * with the saved state on success, and with `undefined` on failure.
+   *
+   * **When nothing answers the handshake the connection is closed**, so requests issued afterwards
+   * are refused at once rather than each waiting out `getRequestTimeout()`. The trigger is
+   * iframe-phone's own 2 second advisory window, which is not proof that CODAP is absent: a CODAP
+   * that is alive but slow to complete the underlying "hello" exchange looks the same from here, and
+   * its connection will be closed. Call `init()` again to retry — it re-establishes the connection.
+   *
+   * Any other failure leaves the connection usable and fails only the handshake, since none of them
+   * says anything about whether CODAP is there: CODAP answering and declining, CODAP answering with
+   * no value, and the request failing to send are all in this group. So is a handshake that goes
+   * silent after CODAP has already answered something else.
+   *
    * @param iConfig {object} Configuration. Optional properties: title {string},
    *                        version {string}, dimensions {object}
    *
-   * @param iCallback {function(interactiveState)}
+   * @param iCallback {function(interactiveState)} Optional. Receives the saved state, or `undefined`
+   *                        if the handshake failed.
    * @return {Promise} Promise of interactiveState;
    */
   init (iConfig: IConfig, iCallback?: (arg0: any) => void) {
@@ -577,7 +602,7 @@ export const codapInterface = {
       function rejectHandshake(reason: unknown) {
         reject(reason instanceof Error ? reason : new Error(String(reason)));
         // the callback reports every outcome, as sendRequest's does; there is no state to pass on
-        notifyInitCallback(iCallback, undefined);
+        afterHandshake(iCallback, undefined);
       }
 
       /**
@@ -596,16 +621,25 @@ export const codapInterface = {
        *
        * Silence here is weaker evidence than it looks: iframe-phone arms its 2s timer when `call` is
        * invoked but queues the message until the parent answers its repeated hello, so the window
-       * covers that exchange as well as the round trip. What it does not cover is CODAP thinking
-       * hard — the handshake asks it to do nothing expensive — which is what separates it from the
-       * slow requests this deadline handling exists to stop failing.
+       * covers that exchange as well as the round trip. Set against that, the handshake asks CODAP
+       * for much less work than the requests this deadline handling exists to stop failing: reading
+       * the interactive frame is a bare read, though the update half of it does set name, title and
+       * dimensions, which makes CODAP resize and reposition the component in a live document. So
+       * this is a judgement about relative likelihood, not a proof — which is why anything CODAP has
+       * already been seen answering overrides it, above.
        *
        * Only this handshake's own endpoint is closed. Two `init()` calls can overlap — React's
        * StrictMode double-invokes effects, and the README's example initializes in one — and the
        * loser must not close the connection the winner established.
        */
       function closeSilentConnection() {
-        if (connection === endpoint) {
+        // "active" means something from CODAP has already arrived — a reply to any request, or a
+        // notification. That is positive evidence it is there, and it outranks this handshake's
+        // silence: an ordinary request can be answered while the handshake is still outstanding, and
+        // an earlier init() can have been answered on a connection this one has since replaced.
+        // `init()` sets the state back to "preinit" before each handshake, so a deliberate re-init
+        // that genuinely draws no reply still closes the connection.
+        if (connection === endpoint && connectionState !== "active") {
           connection = null;
           connectionState = "closed";
         }
@@ -623,10 +657,10 @@ export const codapInterface = {
           // forever with the exception discarded into a promise nothing observes. Same reasoning as
           // the callbacks below, so it settles first and reports the same way.
           resolve(savedState);
-          notifyInitCallback(state => this_.updateInteractiveState(state), savedState);
+          afterHandshake(state => this_.updateInteractiveState(state), savedState);
           // deprecated way of conveying state
-          notifyInitCallback(iConfig.stateHandler, savedState);
-          notifyInitCallback(iCallback, savedState);
+          afterHandshake(iConfig.stateHandler, savedState);
+          afterHandshake(iCallback, savedState);
         } else {
           // CODAP answered and declined, so the connection is alive and stays usable
           rejectHandshake((resp[1] && resp[1].values && resp[1].values.error) || "unknown failure");

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -101,7 +101,8 @@ const stats = {
   countDiRplFail: 0,
   /**
    * How many requests failed, and so rejected: no connection to send on, no answer within the
-   * deadline, an answer carrying no result, or the send itself throwing.
+   * deadline, an answer carrying no result, the send itself throwing, or — for `init()`'s handshake
+   * alone — nothing answering within iframe-phone's advisory window.
    *
    * `countDiReq - countDiRplSuccess - countDiRplFail - countDiReqFailed` is the number still in
    * flight. `countDiReqDeadlineExceeded` counts the subset that ran out of time.
@@ -462,15 +463,20 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
           // so this is not an outcome — except during the handshake, where silence is the answer.
           stats.countDiRplTimeout++;
           if (onSilence) {
-            // `finally`, because this runs inside iframe-phone's message listener: a throw from a
-            // supplied function must not leave the request unsettled and escape into that listener,
-            // which is the failure this module exists to prevent. Every other consumer-supplied
-            // function here is guarded the same way.
+            // This runs inside iframe-phone's message listener, so a throw from a supplied function
+            // must neither leave the request unsettled nor escape into that listener — the failure
+            // this module exists to prevent. Reported rather than rethrown, and the request settles
+            // either way, which is how every other supplied function here is handled.
+            //
+            // Defensive: the only `onSilence` today cannot throw, so there is no test for this. It
+            // is guarded because `onSilence` is a general option, and because a supplied function
+            // running on a listener's stack is exactly where this module has been bitten before.
             try {
               onSilence();
-            } finally {
-              settleFailure("handleResponse: CODAP request timed out: " + describeMessage(message));
+            } catch (error) {
+              reportCallbackError(error);
             }
+            settleFailure("handleResponse: CODAP request timed out: " + describeMessage(message));
           }
           return;
         }

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -357,6 +357,12 @@ export const codapInterface = {
           // finishes, so record the delay and keep waiting rather than reporting a failure and
           // discarding a result that is still coming. See `requestTimeout` above.
           stats.countDiRplTimeout++;
+          // Until CODAP has answered something, though, that timer is the liveness signal it was
+          // designed to be: no reply is the evidence that nothing is listening. Keep failing fast
+          // there so a plugin loaded outside CODAP learns in seconds rather than a minute.
+          if (connectionState === "preinit") {
+            settle(reject, "handleResponse: CODAP request timed out: " + JSON.stringify(request));
+          }
           return;
         }
         connectionState = "active";

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -601,7 +601,12 @@ export const codapInterface = {
    * iframe-phone's own 2 second advisory window, which is not proof that CODAP is absent: a CODAP
    * that is alive but slow to complete the underlying "hello" exchange looks the same from here.
    * That guess is not final, though — if CODAP answers after all, the connection reopens by itself
-   * and requests resume. Calling `init()` again also re-establishes it.
+   * and requests resume.
+   *
+   * The reopen recovers the connection, not the handshake: this promise stays rejected, and the saved
+   * state that late reply carried is **not** delivered, so `getInteractiveState()` is still empty. A
+   * plugin that restores state should call `init()` again rather than rely on the reopen — otherwise
+   * it will answer CODAP's next request for its state with nothing, overwriting what was stored.
    *
    * Any other failure leaves the connection usable and fails only the handshake, since none of them
    * says anything about whether CODAP is there: CODAP answering and declining, CODAP answering with
@@ -662,8 +667,14 @@ export const codapInterface = {
         // notification. That is positive evidence it is there, and it outranks this handshake's
         // silence: an ordinary request can be answered while the handshake is still outstanding, and
         // an earlier init() can have been answered on a connection this one has since replaced.
-        // `init()` sets the state back to "preinit" before each handshake, so a deliberate re-init
-        // that genuinely draws no reply still closes the connection.
+        //
+        // `init()` resets the state to "preinit" before each handshake, so what suppresses the close
+        // is activity observed since that reset — not necessarily activity on this endpoint, since
+        // `markConnectionActive` asks only that some connection exists. A reply to a request issued
+        // before an intervening `destroy()` therefore counts. That is deliberate rather than merely
+        // tolerated: every endpoint built against `window.parent` shares one iframe-phone singleton,
+        // so such a reply really is the parent talking, and the parent is what this is evidence
+        // about. A re-init that draws no reply, with nothing else arriving, still closes.
         if (connection === endpoint && connectionState !== "active") {
           // The state is closed but the endpoint is kept. Requests are refused either way, since the
           // `case "closed"` branch does not consult it — but keeping it is what lets a reply arriving
@@ -681,6 +692,14 @@ export const codapInterface = {
         const success = resp && resp[1] && resp[1].success;
         const receivedFrame = success && resp[1].values;
         const savedState = receivedFrame && receivedFrame.savedState;
+        if (!connection) {
+          // `destroy()` ran while this handshake was outstanding. Resolving would hand the caller a
+          // connection they have already torn down — state `"closed"`, every request refused — and
+          // merge saved state into a plugin that is going away. What they did outranks what CODAP
+          // said, so this fails instead.
+          rejectHandshake("init: the connection was destroyed before the handshake completed");
+          return;
+        }
         if (success) {
           // Object.assign onto a value that came out of a saved document can throw -- a getter that
           // throws, a non-writable property -- and before `resolve` that would leave init() pending
@@ -740,8 +759,17 @@ export const codapInterface = {
   },
 
   /**
-   * Current known state of the connection
-   * @param {'preinit' || 'init' || 'active' || 'inactive' || 'closed'}
+   * Current known state of the connection. One of three values:
+   *
+   * - `"preinit"` — no handshake has completed yet, either before the first `init()` or during one.
+   * - `"active"` — CODAP has been heard from: it answered a request, or sent a notification.
+   * - `"closed"` — requests are refused without being sent. Two causes, which behave differently:
+   *   `destroy()`, which is final until `init()` is called again; and a handshake that nothing
+   *   answered, which reverts to `"active"` by itself if CODAP answers after all.
+   *
+   * This is the only way to observe either of those, since neither raises an event.
+   *
+   * @returns {'preinit' | 'active' | 'closed'}
    */
   getConnectionState () {return connectionState;},
 
@@ -811,6 +839,11 @@ export const codapInterface = {
     // can surface against a re-initialized instance. They used to fail within iframe-phone's ~2s by
     // accident. Doing it needs a registry of in-flight requests, since `isSettled` and
     // `timeoutTimer` are locals inside each issueRequest executor.
+    //
+    // A resolution is the sharper case, not a rejection: an outstanding handshake that CODAP answers
+    // after teardown would otherwise resolve `init()` against a connection the caller has closed, and
+    // merge saved state into a plugin that is going away. `getFrameRespHandler` refuses that
+    // explicitly for now; the registry would cover it along with everything else.
     //
     // Unsubscribe from iframe-phone, whose endpoint exposes `disconnect()`: dropping the reference
     // leaves its window message listener installed, so CODAP's notifications still reach

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -77,6 +77,8 @@ const kDefaultRequestTimeout = 60000;
  * fires immediately.
  */
 const kMaxRequestTimeout = 2 ** 31 - 1;
+/** How much of a request to quote in a failure message. See describeMessage. */
+const kMaxDescribedMessage = 500;
 let requestTimeout = kDefaultRequestTimeout;
 
 const stats = {
@@ -307,11 +309,19 @@ function reportCallbackError (error: unknown) {
  * was being failed, leaving it settled by nothing at all.
  */
 function describeMessage (message: unknown) {
+  let described;
   try {
-    return JSON.stringify(message) ?? String(message);
+    described = JSON.stringify(message) ?? String(message);
   } catch {
     return "[message could not be serialized]";
   }
+  // Truncated because the requests likeliest to reach a failure message are the large ones: the
+  // deadline exists for a createItems carrying thousands of items, and serializing that whole
+  // payload into an Error -- then again wherever it is logged -- costs most exactly when the plugin
+  // is already struggling. The head identifies the request, which is what a reader needs.
+  return described.length > kMaxDescribedMessage
+           ? described.slice(0, kMaxDescribedMessage) + "… (truncated)"
+           : described;
 }
 
 /**
@@ -461,6 +471,16 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
       settleSuccess(response);
     }
 
+    // Counted here rather than beside `connection.call`, so that a request refused before it could
+    // be sent still counts as one the caller issued. Counting only the sent ones let the refusal
+    // paths increment countDiReqFailed against a countDiReq that had not moved, and the documented
+    // in-flight arithmetic then went negative.
+    stats.countDiReq++;
+    stats.timeDiLastReq = new Date();
+    if (!stats.timeDiFirstReq) {
+      stats.timeDiFirstReq = stats.timeDiLastReq;
+    }
+
     switch (connectionState) {
       case "closed": // log the message and ignore
         // console.warn('sendRequest on closed CODAP connection: ' + JSON.stringify(message));
@@ -472,12 +492,6 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
         /* falls through */
       default:
         if (connection) {
-          stats.countDiReq++;
-          stats.timeDiLastReq = new Date();
-          if (!stats.timeDiFirstReq) {
-            stats.timeDiFirstReq = stats.timeDiLastReq;
-          }
-
           // `call` can throw synchronously — an uncloneable value in the message makes postMessage
           // raise DataCloneError. Settling here rather than letting the throw escape the executor is
           // what keeps the callback contract true on this path: an escaped throw rejects the promise
@@ -494,11 +508,18 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
             // Capture the deadline this request was given, so a later setRequestTimeout() can't
             // make the reported duration disagree with the timer that actually fired.
             const timeout = requestTimeout;
-            timeoutTimer = setTimeout(function () {
-              stats.countDiReqDeadlineExceeded++;
-              settleFailure("sendRequest: CODAP request exceeded " + timeout + "ms: " +
-                  describeMessage(message));
-            }, timeout);
+            // Guarded because `settle` can only clear a timer that exists: were `call` ever to
+            // answer synchronously, the request would settle while `timeoutTimer` was still
+            // undefined and this would arm one nothing clears. iframe-phone does not do that today,
+            // and this does not depend on it continuing not to.
+            if (!isSettled) {
+              timeoutTimer = setTimeout(function () {
+                if (isSettled) { return; }
+                stats.countDiReqDeadlineExceeded++;
+                settleFailure("sendRequest: CODAP request exceeded " + timeout + "ms: " +
+                    describeMessage(message));
+              }, timeout);
+            }
           } catch (error) {
             settleFailure(error);
           }
@@ -534,20 +555,44 @@ export const codapInterface = {
     const this_ = this;
     return new Promise(function (resolve: (arg0: any) => void, reject: { (arg0: string): void; (arg0: any): void; }) {
       /**
-       * Fails the handshake, and with it the connection.
+       * Fails the handshake, leaving the connection as it is.
        *
-       * A handshake that got no answer leaves a `connection` object that nothing is listening to.
-       * Left in place it looks live to `issueRequest`, so every later request would be sent and then
-       * wait out the full deadline — a minute per request for a plugin that has already been told it
-       * is not running inside CODAP. Tearing it down means those requests are refused at once,
-       * which is what `init()` rejecting is supposed to have told the caller.
+       * Used when CODAP answered and declined: it is there, and it is listening, so the connection
+       * remains usable and the caller is free to try something else.
        */
-      function failHandshake(reason: unknown) {
-        connection = null;
-        connectionState = "closed";
+      function rejectHandshake(reason: unknown) {
         reject(reason instanceof Error ? reason : new Error(String(reason)));
         // the callback reports every outcome, as sendRequest's does; there is no state to pass on
         notifyInitCallback(iCallback, undefined);
+      }
+
+      /**
+       * Fails the handshake, and closes the connection with it.
+       *
+       * Only for a handshake nothing answered. That leaves an endpoint nothing is listening to, and
+       * left in place it looks live to `issueRequest`, so every later request would be sent and then
+       * wait out the full deadline — a minute apiece for a plugin already told it is not running
+       * inside CODAP. Closing it means those requests are refused at once, which is what `init()`
+       * rejecting is supposed to have told the caller. `init()` can be called again to retry.
+       *
+       * Silence here is weaker evidence than silence would be for an ordinary request, which is why
+       * this is confined to the handshake: iframe-phone arms its 2s timer when `call` is invoked but
+       * queues the message until the parent answers its repeated hello, so the window covers that
+       * exchange as well as the round trip. What it does not cover is CODAP thinking hard — the
+       * handshake asks it to do nothing expensive — so silence is much better evidence of "nothing
+       * is there" here than it would be for a request that asks CODAP to create several thousand
+       * items.
+       *
+       * Only this handshake's own endpoint is torn down. Two `init()` calls can overlap — React's
+       * StrictMode double-invokes effects, and the README's example initializes in one — and the
+       * loser must not close the connection the winner established.
+       */
+      function failHandshake(reason: unknown) {
+        if (connection === endpoint) {
+          connection = null;
+          connectionState = "closed";
+        }
+        rejectHandshake(reason);
       }
 
       function getFrameRespHandler(resp: { values: { error: any; savedState: any }; success: boolean }[]) {
@@ -556,18 +601,19 @@ export const codapInterface = {
         const success = resp && resp[1] && resp[1].success;
         const receivedFrame = success && resp[1].values;
         const savedState = receivedFrame && receivedFrame.savedState;
-        this_.updateInteractiveState(savedState);
         if (success) {
-          // Settle before handing control to the caller's handlers, and keep what they throw out of
-          // this promise — the same contract sendRequest's callback has, for the same reason. Called
-          // the other way round, a stateHandler that threw would leave init() unsettled forever and
-          // its exception discarded, because nothing observes the promise this handler returns into.
+          // Object.assign onto a value that came out of a saved document can throw -- a getter that
+          // throws, a non-writable property -- and before `resolve` that would leave init() pending
+          // forever with the exception discarded into a promise nothing observes. Same reasoning as
+          // the callbacks below, so it settles first and reports the same way.
           resolve(savedState);
+          notifyInitCallback(state => this_.updateInteractiveState(state), savedState);
           // deprecated way of conveying state
           notifyInitCallback(iConfig.stateHandler, savedState);
           notifyInitCallback(iCallback, savedState);
         } else {
-          failHandshake((resp[1] && resp[1].values && resp[1].values.error) || "unknown failure");
+          // CODAP answered and declined, so the connection is alive and stays usable
+          rejectHandshake((resp[1] && resp[1].values && resp[1].values.error) || "unknown failure");
         }
       }
 
@@ -589,8 +635,9 @@ export const codapInterface = {
       config = iConfig;
 
       // initialize connection
-      connection = new IframePhoneRpcEndpoint(
+      const endpoint = new IframePhoneRpcEndpoint(
           notificationHandler, "data-interactive", window.parent);
+      connection = endpoint;
       // Reset the state, so that initializing again after destroy() works. Without this the
       // handshake below would be refused by the `case "closed"` branch in issueRequest, and the
       // connection could never be reestablished.
@@ -713,8 +760,9 @@ export const codapInterface = {
    *   being no connection to send on (before `initializePlugin()` or after `destroy()`), CODAP
    *   answering with no value at all, and the send itself throwing.
    *
-   * The callback is invoked exactly once, after the promise has settled. A callback written as
-   * `result.success` therefore has to handle the `undefined` it receives on failure. Note that the
+   * The callback is invoked exactly once, synchronously after the promise is resolved or rejected —
+   * that is, before any `.then` or `await` continuation runs, since those are microtasks. A callback
+   * written as `result.success` therefore has to handle the `undefined` it receives on failure. Note that the
    * promise rejects whether or not a callback is passed, so it still needs a `.catch` to avoid an
    * unhandled rejection. An exception thrown by the callback itself is rethrown as an uncaught error
    * rather than failing the request, which has already settled by then.

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -379,7 +379,7 @@ export const codapInterface = {
             stats.countDiReq++;
             stats.timeDiLastReq = new Date();
             if (!stats.timeDiFirstReq) {
-              stats.timeCodapFirstReq = stats.timeDiLastReq;
+              stats.timeDiFirstReq = stats.timeDiLastReq;
             }
 
             // Capture the deadline this request was given, so a later setRequestTimeout() can't

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -210,6 +210,20 @@ interface IRequestOptions {
 }
 
 /**
+ * Reports an exception thrown by a caller's request callback.
+ *
+ * By the time the callback runs its request has already settled, so what it throws is not the
+ * request's failure and must not escape into the stack that invoked it — iframe-phone's message
+ * listener (where a throw skips its own bookkeeping), the deadline timer, or the promise executor
+ * (which discards it silently, since the promise has settled). Rethrowing on a fresh task keeps it
+ * out of all three while leaving it an uncaught error, so `window.onerror` and error reporters
+ * still see it: logging it instead would hide a consumer's bug from the monitoring they rely on.
+ */
+function reportCallbackError (error: unknown) {
+  queueMicrotask(() => { throw error; });
+}
+
+/**
  * Issues a request to CODAP and returns a promise of the response.
  */
 function issueRequest (message: any, options: IRequestOptions = {}) {
@@ -228,13 +242,17 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
       if (timeoutTimer !== undefined) { clearTimeout(timeoutTimer); }
       settleFn(value);
       if (callback) {
-        // A callback written for the success case may not expect `undefined`; a throw from it
-        // must not escape into the timer or the promise executor that settled the request.
+        // A callback written for the success case may not expect `undefined`. Whatever it throws
+        // must not escape into iframe-phone's listener, the deadline timer, or this executor —
+        // see reportCallbackError.
         try {
-          callback(callbackResponse, message);
+          const callbackResult = callback(callbackResponse, message);
+          // an async callback reports a throw as a rejected return value, which the catch can't see
+          if (callbackResult && typeof callbackResult.then === "function") {
+            callbackResult.then(undefined, reportCallbackError);
+          }
         } catch (error) {
-          // eslint-disable-next-line no-console
-          console.warn("codapInterface: request callback threw", error);
+          reportCallbackError(error);
         }
       }
     }
@@ -270,6 +288,14 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
             stats.timeDiFirstReq = stats.timeDiLastReq;
           }
 
+          // Issue the request before arming the deadline. `call` can throw synchronously — an
+          // uncloneable value in the message makes postMessage raise DataCloneError — and that
+          // throw rejects this promise directly, without going through settle(). A timer armed
+          // first would survive that, and fire a spurious failure at the deadline. iframe-phone
+          // never invokes the callback synchronously, so nothing can settle before the timer
+          // exists.
+          connection.call(message, handleResponse);
+
           // Capture the deadline this request was given, so a later setRequestTimeout() can't
           // make the reported duration disagree with the timer that actually fired.
           const timeout = requestTimeout;
@@ -277,8 +303,6 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
             settle(reject, "sendRequest: CODAP request exceeded " + timeout + "ms: " +
                 JSON.stringify(message));
           }, timeout);
-
-          connection.call(message, handleResponse);
         } else {
           // Nothing will ever call back, so settle now rather than leaving the caller waiting
           // forever — the same guarantee the deadline provides once a request is in flight.

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -82,7 +82,14 @@ const kMaxDescribedMessage = 500;
 let requestTimeout = kDefaultRequestTimeout;
 
 const stats = {
-  /** How many requests were sent to CODAP. */
+  /**
+   * How many requests the caller issued.
+   *
+   * Counted when `sendRequest` is called, not when the request reaches CODAP, so a request refused
+   * before it could be sent — no connection, or a closed one — is included. That is what makes the
+   * arithmetic on `countDiReqFailed` below hold; counting only the ones that got as far as CODAP
+   * left the refusals incrementing a failure count against a total that had not moved.
+   */
   countDiReq: 0,
   /** How many requests CODAP answered with `{success: true}`. */
   countDiRplSuccess: 0,

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -361,10 +361,23 @@ function afterHandshake (step: ((state: any) => void) | undefined, state: any) {
 }
 
 /**
- * Records that CODAP is talking to us — unless the caller has torn the connection down, in which
- * case traffic still arriving must not reopen a connection they closed. `destroy()` does not
- * unsubscribe from iframe-phone, and a reply to a request that was already in flight can arrive
- * after it, so both this module's inbound paths have to check.
+ * Records that CODAP is talking to us. This is the module's only source of positive evidence that
+ * CODAP is there, and both inbound paths — replies and notifications — run through it.
+ *
+ * It exists to serve one rule, which the connection lifecycle rests on:
+ *
+ *   **Silence is only ever evidence of absence, and anything CODAP has actually done outranks it.**
+ *
+ * Silence means iframe-phone's advisory 2s timer expiring with no reply, and the only place this
+ * module acts on it is `init()`'s handshake. Evidence outranks it in all three senses: by cause,
+ * since a failure that is not silence — CODAP declining, answering emptily, a message that could not
+ * be sent — is not evidence of absence at all; by state, since a reply or notification already seen
+ * means the connection stays open however the handshake ends; and by time, since evidence arriving
+ * after silence was acted on reopens the connection rather than being discarded for being late.
+ *
+ * The exception is `destroy()`, which is the caller deciding rather than this module inferring. It
+ * drops the endpoint, so the `connection` check below fails and traffic still arriving — `destroy()`
+ * does not unsubscribe from iframe-phone — cannot reopen a connection the caller closed.
  */
 function markConnectionActive () {
   if (connection) {

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -152,6 +152,19 @@ export interface ClientNotification {
 }
 export type ClientHandler = (notification: ClientNotification) => void;
 
+/**
+ * What `sendRequest` passes a callback: CODAP's response, or `undefined` if the request failed.
+ *
+ * The `undefined` is the point of the type. A callback declared to take `IResult` alone does not
+ * satisfy it, and will not compile — which is the intent, because such a callback throws a
+ * `TypeError` the first time a request fails, on a path a plugin may not exercise until it is in
+ * front of users.
+ *
+ * A batched request — an array of requests — is answered with an array of results. That does not fit
+ * here, so batch through the returned promise rather than a callback.
+ */
+export type RequestCallback = (response?: IResult, request?: any) => void;
+
 let interactiveState = {};
 
 /**
@@ -238,14 +251,8 @@ interface IRequestOptions {
    * Invoked with the response on success and with `undefined` on failure. See `sendRequest`, whose
    * JSDoc carries this contract for consumers — this interface is module-private and never reaches
    * the published type declarations.
-   *
-   * TODO: type this as `(response?: IResult, request?: any) => void`. As `any` it accepts a
-   * consumer's `(result: IResult) => result.success`, which compiles and then throws the first time
-   * a request goes unanswered — the very defect this contract exists to prevent — and it is why the
-   * helpers' signatures had to be corrected by hand rather than by the compiler. Tightening it
-   * breaks consumers' builds, so it belongs in a release that expects to.
    */
-  callback?: any
+  callback?: RequestCallback
   /**
    * Reject as soon as iframe-phone reports no reply, instead of waiting out `requestTimeout`.
    *
@@ -354,10 +361,12 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
         // must not escape into iframe-phone's listener, the deadline timer, or this executor —
         // see reportCallbackError.
         try {
-          const callbackResult = callback(callbackResponse, message);
-          // an async callback reports a throw as a rejected return value, which the catch can't see
-          if (callbackResult && typeof callbackResult.then === "function") {
-            callbackResult.then(undefined, reportCallbackError);
+          // An async callback reports a throw as a rejected return value, which the catch can't see.
+          // `RequestCallback` returns `void`, but TypeScript lets a callback in that position return
+          // a value anyway, so an async one arrives here as a promise and has to be observed.
+          const callbackResult = callback(callbackResponse, message) as unknown;
+          if (callbackResult && typeof (callbackResult as PromiseLike<unknown>).then === "function") {
+            (callbackResult as PromiseLike<unknown>).then(undefined, reportCallbackError);
           }
         } catch (error) {
           reportCallbackError(error);
@@ -684,12 +693,14 @@ export const codapInterface = {
    * rather than failing the request, which has already settled by then.
    *
    * @param message {Object} The request, as in the Data Interactive API.
-   * @param callback {function(response, request)} Optional. Receives the response, or `undefined`
-   *    if the request failed, followed by the original request.
+   * @param callback {RequestCallback} Optional. Receives the response, or `undefined` if the request
+   *    failed, followed by the original request. Its parameter has to admit `undefined`: a callback
+   *    typed for the response alone does not compile, because it is the one that throws when a
+   *    request fails.
    *
    * @return {Promise} The promise of the response from CODAP.
    */
-  sendRequest (message: any, callback?: any) {
+  sendRequest (message: any, callback?: RequestCallback) {
     return issueRequest(message, { callback });
   },
 

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -449,9 +449,16 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
      *    the request at once. See `connection`'s type for why this argument has to be declared.
      */
     function handleResponse (response: CodapResponse | undefined | null, noReplyYet?: Error) {
+      // Anything other than the probe is CODAP replying, and a reply is evidence it is there whenever
+      // it arrives — including for a request that has already given up on it. Recorded before the
+      // settled check, so that evidence is never discarded for arriving late: a CODAP slow to finish
+      // iframe-phone's hello exchange answers a handshake that has already been failed for silence,
+      // and that answer is what reopens the connection.
+      if (!noReplyYet) { markConnectionActive(); }
+
       // A reply can still arrive after the deadline rejected the request. Returning early keeps it
-      // from marking the connection active or counting a success against a request the caller has
-      // already been told failed.
+      // from counting a success, or settling again, against a request the caller has already been
+      // told failed.
       if (isSettled) { return; }
 
       // `null` is grouped with `undefined` deliberately: it is just as empty an answer, and reading
@@ -483,11 +490,9 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
         // CODAP answered, with no value. That is a real answer and settles the request, but there
         // is no result for the caller to read, so it fails rather than resolving with `undefined`
         // and handing the caller something `result.success` throws on.
-        markConnectionActive();
         settleFailure("handleResponse: CODAP answered with no result: " + describeMessage(message));
         return;
       }
-      markConnectionActive();
       // A batched request — an array of requests — is answered with an array of results, which has no
       // top-level `success` to read. It counts as the one request it was, and as a success only if
       // every result in it succeeded, so the counters keep reconciling against `countDiReq`. A reply
@@ -578,11 +583,12 @@ export const codapInterface = {
    * if the handshake does not succeed. The callback is invoked either way, as `sendRequest`'s is:
    * with the saved state on success, and with `undefined` on failure.
    *
-   * **When nothing answers the handshake the connection is closed**, so requests issued afterwards
-   * are refused at once rather than each waiting out `getRequestTimeout()`. The trigger is
+   * **When nothing answers the handshake the connection is marked closed**, so requests issued
+   * afterwards are refused at once rather than each waiting out `getRequestTimeout()`. The trigger is
    * iframe-phone's own 2 second advisory window, which is not proof that CODAP is absent: a CODAP
-   * that is alive but slow to complete the underlying "hello" exchange looks the same from here, and
-   * its connection will be closed. Call `init()` again to retry — it re-establishes the connection.
+   * that is alive but slow to complete the underlying "hello" exchange looks the same from here.
+   * That guess is not final, though — if CODAP answers after all, the connection reopens by itself
+   * and requests resume. Calling `init()` again also re-establishes it.
    *
    * Any other failure leaves the connection usable and fails only the handshake, since none of them
    * says anything about whether CODAP is there: CODAP answering and declining, CODAP answering with
@@ -646,7 +652,12 @@ export const codapInterface = {
         // `init()` sets the state back to "preinit" before each handshake, so a deliberate re-init
         // that genuinely draws no reply still closes the connection.
         if (connection === endpoint && connectionState !== "active") {
-          connection = null;
+          // The state is closed but the endpoint is kept. Requests are refused either way, since the
+          // `case "closed"` branch does not consult it — but keeping it is what lets a reply arriving
+          // later reopen the connection, through `markConnectionActive`. A CODAP merely slow to
+          // finish iframe-phone's hello exchange therefore recovers by itself, rather than being
+          // locked out by a guess made at two seconds. `destroy()` is the deliberate teardown, and
+          // that one does drop the endpoint.
           connectionState = "closed";
         }
       }

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -283,7 +283,13 @@ export const codapInterface = {
    */
   getRequestTimeout () {return requestTimeout;},
 
-  setRequestTimeout (timeout: number) {requestTimeout = timeout;},
+  /**
+   * A non-finite or non-positive value falls back to the default: setTimeout treats NaN and
+   * negative delays as 0, which would silently make every subsequent request fail at once.
+   */
+  setRequestTimeout (timeout: number) {
+    requestTimeout = Number.isFinite(timeout) && timeout > 0 ? timeout : kDefaultRequestTimeout;
+  },
 
   getStats () {
     return stats;
@@ -376,16 +382,21 @@ export const codapInterface = {
               stats.timeCodapFirstReq = stats.timeDiLastReq;
             }
 
+            // Capture the deadline this request was given, so a later setRequestTimeout() can't
+            // make the reported duration disagree with the timer that actually fired.
+            const timeout = requestTimeout;
             timeoutTimer = setTimeout(function () {
-              settle(reject, "sendRequest: CODAP request exceeded " + requestTimeout + "ms: " +
+              settle(reject, "sendRequest: CODAP request exceeded " + timeout + "ms: " +
                   JSON.stringify(message));
-            }, requestTimeout);
+            }, timeout);
 
             connection.call(message, function (response: any) {
               handleResponse(message, response, callback);
             });
           } else {
-            // console.error('sendRequest on non-existent CODAP connection');
+            // Nothing will ever call back, so settle now rather than leaving the caller waiting
+            // forever — the same guarantee the hard timeout provides once a request is in flight.
+            settle(reject, "sendRequest on non-existent CODAP connection: " + JSON.stringify(message));
           }
       }
     });

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -195,7 +195,15 @@ function notificationHandler (request: { action: any; resource: any; values: any
 }
 
 interface IRequestOptions {
-  /** Invoked with the response on success and with `undefined` on failure. */
+  /**
+   * Invoked with the response on success and with `undefined` on failure.
+   *
+   * TODO: type this as `(response?: IResult, request?: any) => void`. As `any` it accepts a
+   * consumer's `(result: IResult) => result.success`, which compiles and then throws the first time
+   * a request goes unanswered — the very defect this contract exists to prevent — and it is why the
+   * helpers' signatures had to be corrected by hand rather than by the compiler. Tightening it
+   * breaks consumers' builds, so it belongs in a release that expects to.
+   */
   callback?: any
   /**
    * Reject as soon as iframe-phone reports no reply, instead of waiting out `requestTimeout`.
@@ -260,6 +268,10 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
     function handleResponse (response: {success: boolean} | undefined) {
       if (response === undefined) {
         // iframe-phone's advisory timer expired; the reply is still coming. See kDefaultRequestTimeout.
+        // TODO: a request CODAP genuinely answers with no value arrives here identically, and now
+        // waits out the full deadline rather than failing in ~2s. iframe-phone does distinguish the
+        // two — its advisory call passes a second argument, `callback(undefined, new Error(
+        // "IframePhone timed out waiting for reply"))` — which this handler discards.
         stats.countDiRplTimeout++;
         if (failFastWithoutReply) {
           settle(reject, "handleResponse: CODAP request timed out: " + JSON.stringify(message));
@@ -267,6 +279,9 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
         return;
       }
       connectionState = "active";
+      // TODO: a batched request is answered with an array, which has no top-level `success`, so
+      // every successful init() handshake is counted a failure here. These counters are diagnostic
+      // only, but they mislead whoever reads getStats() to find out why a plugin is misbehaving.
       if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
       settle(resolve, response, response);
     }
@@ -454,7 +469,13 @@ export const codapInterface = {
   },
 
   destroy () {
-    // todo : more to do?
+    // TODO: settle the requests still in flight. Nulling the connection leaves each of them to wait
+    // out its full deadline — a minute in which the caller holds its payload alive after the plugin
+    // is gone, ending in a rejection that can surface against a re-initialized instance. They used
+    // to fail within iframe-phone's ~2s by accident. Settling them needs a registry of in-flight
+    // requests, since `isSettled` and `timeoutTimer` are locals inside each issueRequest executor;
+    // a destroyed connection should refuse new requests too, which `connectionState = "closed"`
+    // would do.
     connection = null;
   },
 

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -269,20 +269,26 @@ interface IRequestOptions {
    */
   callback?: EitherRequestCallback
   /**
-   * Reject as soon as iframe-phone reports no reply, instead of waiting out `requestTimeout`.
+   * Treat silence as an outcome: fail as soon as iframe-phone reports no reply, rather than waiting
+   * out `requestTimeout`, running this first.
    *
-   * Set only for the handshake in `init()`, and a deliberate trade rather than a safe inference.
+   * Supplied only by the handshake in `init()`, and a deliberate trade rather than a safe inference.
    * Silence at 2s does not prove nothing is listening: iframe-phone buffers into `postMessageQueue`
    * until the parent answers its repeated "hello", while the 2s probe is armed when `call` is
    * invoked — so a parent slow to complete that exchange looks the same as no parent at all. We
    * accept that, because the alternative is a plugin loaded outside CODAP hanging for the full
    * request timeout before it can say so, and because a plugin that does load in CODAP can retry.
    *
+   * It is a callback rather than a flag so that acting on silence is *caused by* observing silence.
+   * Inferring it from the request having failed catches every other way a request can fail with it —
+   * CODAP declining, CODAP answering emptily, the message failing to post — none of which say
+   * anything about whether CODAP is there.
+   *
    * This is a property of the individual request rather than of the connection state, so an
    * ordinary request issued while the handshake is outstanding is still treated as an ordinary
    * request.
    */
-  failFastWithoutReply?: boolean
+  onSilence?: () => void
 }
 
 /**
@@ -360,7 +366,7 @@ function markConnectionActive () {
  * Issues a request to CODAP and returns a promise of the response.
  */
 function issueRequest (message: any, options: IRequestOptions = {}) {
-  const { callback, failFastWithoutReply = false } = options;
+  const { callback, onSilence } = options;
   return new Promise(function (resolve, reject) {
     let isSettled = false;
     let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
@@ -446,7 +452,8 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
           // Nothing has answered within iframe-phone's advisory 2s. The request is still in flight,
           // so this is not an outcome — except during the handshake, where silence is the answer.
           stats.countDiRplTimeout++;
-          if (failFastWithoutReply) {
+          if (onSilence) {
+            onSilence();
             settleFailure("handleResponse: CODAP request timed out: " + describeMessage(message));
           }
           return;
@@ -567,37 +574,39 @@ export const codapInterface = {
       }
 
       /**
-       * Fails the handshake, and closes the connection with it.
+       * Closes the connection, because nothing answered the handshake.
        *
-       * Only for a handshake nothing answered. That leaves an endpoint nothing is listening to, and
-       * left in place it looks live to `issueRequest`, so every later request would be sent and then
-       * wait out the full deadline — a minute apiece for a plugin already told it is not running
-       * inside CODAP. Closing it means those requests are refused at once, which is what `init()`
-       * rejecting is supposed to have told the caller. `init()` can be called again to retry.
+       * Passed as `onSilence`, so this runs when silence is *observed* rather than when the handshake
+       * is found to have failed. Every other way it can fail — CODAP declining, CODAP answering
+       * emptily, the message failing to post — says nothing about whether CODAP is there, and leaves
+       * the connection alone.
        *
-       * Silence here is weaker evidence than silence would be for an ordinary request, which is why
-       * this is confined to the handshake: iframe-phone arms its 2s timer when `call` is invoked but
-       * queues the message until the parent answers its repeated hello, so the window covers that
-       * exchange as well as the round trip. What it does not cover is CODAP thinking hard — the
-       * handshake asks it to do nothing expensive — so silence is much better evidence of "nothing
-       * is there" here than it would be for a request that asks CODAP to create several thousand
-       * items.
+       * An endpoint nothing is listening to looks live to `issueRequest`, so left in place every
+       * later request would be sent and then wait out the full deadline: a minute apiece for a plugin
+       * already told it is not running inside CODAP. Closing it means those are refused at once,
+       * which is what `init()` rejecting is supposed to have told the caller, and `init()` can be
+       * called again to retry.
        *
-       * Only this handshake's own endpoint is torn down. Two `init()` calls can overlap — React's
+       * Silence here is weaker evidence than it looks: iframe-phone arms its 2s timer when `call` is
+       * invoked but queues the message until the parent answers its repeated hello, so the window
+       * covers that exchange as well as the round trip. What it does not cover is CODAP thinking
+       * hard — the handshake asks it to do nothing expensive — which is what separates it from the
+       * slow requests this deadline handling exists to stop failing.
+       *
+       * Only this handshake's own endpoint is closed. Two `init()` calls can overlap — React's
        * StrictMode double-invokes effects, and the README's example initializes in one — and the
        * loser must not close the connection the winner established.
        */
-      function failHandshake(reason: unknown) {
+      function closeSilentConnection() {
         if (connection === endpoint) {
           connection = null;
           connectionState = "closed";
         }
-        rejectHandshake(reason);
       }
 
       function getFrameRespHandler(resp: { values: { error: any; savedState: any }; success: boolean }[]) {
         // `resp` is always defined here: a handshake that drew no reply rejects rather than
-        // resolving, so it reaches failHandshake instead of this function.
+        // resolving, so it reaches rejectHandshake instead of this function.
         const success = resp && resp[1] && resp[1].success;
         const receivedFrame = success && resp[1].values;
         const savedState = receivedFrame && receivedFrame.savedState;
@@ -654,8 +663,8 @@ export const codapInterface = {
 
       // console.log('sending interactiveState: ' + JSON.stringify(this_.getInteractiveState));
       // update, then get the interactiveFrame.
-      return issueRequest([updateFrameReq, getFrameReq], { failFastWithoutReply: true })
-        .then(getFrameRespHandler as any, failHandshake);
+      return issueRequest([updateFrameReq, getFrameReq], { onSilence: closeSilentConnection })
+        .then(getFrameRespHandler as any, rejectHandshake);
     }.bind(this));
   },
 

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -42,12 +42,21 @@
  */
 
 import { IframePhoneRpcEndpoint } from "iframe-phone";
+// type-only, so the cycle with codap-helper (which imports codapInterface from here) is erased
+import type { IResult } from "./codap-helper";
 
 /**
  * The CODAP Connection
  * @param {iframePhone.IframePhoneRpcEndpoint}
+ *
+ * The callback signature spells out both arguments iframe-phone passes. It invokes the callback
+ * with the reply alone when CODAP answers, and with `(undefined, Error)` when its own advisory 2s
+ * timer expires — the second argument is the only thing distinguishing that probe from CODAP
+ * answering with no value, so an annotation taking one argument silently discards the distinction.
  */
-let connection: { call: (arg0: any, arg1: (response: any) => void) => void; } | null = null;
+let connection: {
+  call: (message: any, callback: (response: any, noReplyYet?: Error) => void) => void;
+} | null = null;
 
 let connectionState = "preinit";
 
@@ -74,7 +83,16 @@ const stats = {
   countDiReq: 0,
   countDiRplSuccess: 0,
   countDiRplFail: 0,
+  /**
+   * How many times iframe-phone's advisory 2s timer has reported that no reply has arrived yet.
+   *
+   * This counts probes, not failures. A request slower than 2s that goes on to succeed normally
+   * increments it, so on a plugin doing bulk work a high count is expected and says nothing is
+   * wrong. For requests that actually ran out of time, see `countDiReqDeadlineExceeded`.
+   */
   countDiRplTimeout: 0,
+  /** How many requests were rejected for exceeding their deadline. See `setRequestTimeout`. */
+  countDiReqDeadlineExceeded: 0,
   countCodapReq: 0,
   countCodapUnhandledReq: 0,
   countCodapRplSuccess: 0,
@@ -134,7 +152,12 @@ function notificationHandler (request: { action: any; resource: any; values: any
   let requestValues = request.values;
   let returnMessage = {success: true};
 
-  connectionState = "active";
+  // CODAP is talking to us, so the connection is live — unless we have torn it down, in which case
+  // a notification still arriving (destroy() does not unsubscribe from iframe-phone) must not
+  // reopen a connection the caller has closed.
+  if (connection) {
+    connectionState = "active";
+  }
   stats.countCodapReq += 1;
   stats.timeCodapLastReq = new Date();
   if (!stats.timeCodapFirstReq) {
@@ -196,7 +219,9 @@ function notificationHandler (request: { action: any; resource: any; values: any
 
 interface IRequestOptions {
   /**
-   * Invoked with the response on success and with `undefined` on failure.
+   * Invoked with the response on success and with `undefined` on failure. See `sendRequest`, whose
+   * JSDoc carries this contract for consumers — this interface is module-private and never reaches
+   * the published type declarations.
    *
    * TODO: type this as `(response?: IResult, request?: any) => void`. As `any` it accepts a
    * consumer's `(result: IResult) => result.success`, which compiles and then throws the first time
@@ -223,9 +248,10 @@ interface IRequestOptions {
  * By the time the callback runs its request has already settled, so what it throws is not the
  * request's failure and must not escape into the stack that invoked it — iframe-phone's message
  * listener (where a throw skips its own bookkeeping), the deadline timer, or the promise executor
- * (which discards it silently, since the promise has settled). Rethrowing on a fresh task keeps it
- * out of all three while leaving it an uncaught error, so `window.onerror` and error reporters
- * still see it: logging it instead would hide a consumer's bug from the monitoring they rely on.
+ * (which discards it silently, since the promise has settled). Rethrowing from a microtask keeps it
+ * out of all three, since those stacks have unwound by the time it runs, while leaving it an
+ * uncaught error that `window.onerror` and error reporters still see: logging it instead would hide
+ * a consumer's bug from the monitoring they rely on.
  */
 function reportCallbackError (error: unknown) {
   queueMicrotask(() => { throw error; });
@@ -244,7 +270,12 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
     // with the response on success, and with `undefined` on failure. Callers may pass a callback
     // and discard the promise — several helpers in this package do — so for them the callback is
     // the only signal that the request is over.
-    function settle (settleFn: (value?: any) => void, value: any, callbackResponse?: any) {
+    //
+    // Success and failure go through separate entry points rather than one function with an
+    // optional callback argument: what the callback receives is then fixed by which one is called,
+    // so a path added later cannot resolve the promise correctly while notifying its callback with
+    // `undefined`.
+    function settle (settleFn: (value?: any) => void, value: any, callbackResponse?: IResult) {
       if (isSettled) { return; }
       isSettled = true;
       if (timeoutTimer !== undefined) { clearTimeout(timeoutTimer); }
@@ -265,17 +296,50 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
       }
     }
 
-    function handleResponse (response: {success: boolean} | undefined) {
+    function settleSuccess (response: IResult) {
+      settle(resolve, response, response);
+    }
+
+    /**
+     * Fails the request. Rejects with an Error — never a string — so a consumer's `.catch` gets a
+     * stack, and so every rejection from this module has one shape to handle. Takes `unknown` so
+     * that a caught exception can be passed straight through without each call site repeating the
+     * same normalization.
+     */
+    function settleFailure (reason: unknown) {
+      settle(reject, reason instanceof Error ? reason : new Error(String(reason)));
+    }
+
+    /**
+     * @param response CODAP's reply, or `undefined` if there is none yet.
+     * @param noReplyYet present only when iframe-phone is reporting that its own advisory 2s timer
+     *    expired. That is a liveness probe, not a completion deadline: the request is still in
+     *    flight and the real reply will arrive at this same callback. A genuinely empty reply from
+     *    CODAP arrives as `undefined` with this argument absent, which is a real answer and settles
+     *    the request at once. See `connection`'s type for why this argument has to be declared.
+     */
+    function handleResponse (response: IResult | undefined, noReplyYet?: Error) {
+      // A reply can still arrive after the deadline rejected the request. Returning early keeps it
+      // from marking the connection active or counting a success against a request the caller has
+      // already been told failed.
+      if (isSettled) { return; }
+
       if (response === undefined) {
-        // iframe-phone's advisory timer expired; the reply is still coming. See kDefaultRequestTimeout.
-        // TODO: a request CODAP genuinely answers with no value arrives here identically, and now
-        // waits out the full deadline rather than failing in ~2s. iframe-phone does distinguish the
-        // two — its advisory call passes a second argument, `callback(undefined, new Error(
-        // "IframePhone timed out waiting for reply"))` — which this handler discards.
-        stats.countDiRplTimeout++;
-        if (failFastWithoutReply) {
-          settle(reject, "handleResponse: CODAP request timed out: " + JSON.stringify(message));
+        if (noReplyYet) {
+          // Nothing has answered within iframe-phone's advisory 2s. The request is still in flight,
+          // so this is not an outcome — except during the handshake, where silence is the answer.
+          stats.countDiRplTimeout++;
+          if (failFastWithoutReply) {
+            settleFailure("handleResponse: CODAP request timed out: " + JSON.stringify(message));
+          }
+          return;
         }
+        // CODAP answered, with no value. That is a real answer and settles the request, but there
+        // is no result for the caller to read, so it fails rather than resolving with `undefined`
+        // and handing the caller something `result.success` throws on.
+        connectionState = "active";
+        stats.countDiRplFail++;
+        settleFailure("handleResponse: CODAP answered with no result: " + JSON.stringify(message));
         return;
       }
       connectionState = "active";
@@ -283,13 +347,13 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
       // every successful init() handshake is counted a failure here. These counters are diagnostic
       // only, but they mislead whoever reads getStats() to find out why a plugin is misbehaving.
       if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
-      settle(resolve, response, response);
+      settleSuccess(response);
     }
 
     switch (connectionState) {
       case "closed": // log the message and ignore
         // console.warn('sendRequest on closed CODAP connection: ' + JSON.stringify(message));
-        settle(reject, "sendRequest on closed CODAP connection: " + JSON.stringify(message));
+        settleFailure("sendRequest on closed CODAP connection: " + JSON.stringify(message));
         break;
       case "preinit": // warn, but issue request.
         // console.log('sendRequest on not yet initialized CODAP connection: ' +
@@ -303,25 +367,38 @@ function issueRequest (message: any, options: IRequestOptions = {}) {
             stats.timeDiFirstReq = stats.timeDiLastReq;
           }
 
-          // Issue the request before arming the deadline. `call` can throw synchronously — an
-          // uncloneable value in the message makes postMessage raise DataCloneError — and that
-          // throw rejects this promise directly, without going through settle(). A timer armed
-          // first would survive that, and fire a spurious failure at the deadline. iframe-phone
-          // never invokes the callback synchronously, so nothing can settle before the timer
-          // exists.
-          connection.call(message, handleResponse);
+          // Issue the request before arming the deadline, and settle if it throws. `call` can throw
+          // synchronously — an uncloneable value in the message makes postMessage raise
+          // DataCloneError. Settling here rather than letting the throw escape the executor is what
+          // keeps the callback contract true on this path: an escaped throw rejects the promise
+          // without ever passing through settle(), so the caller's callback would never fire.
+          //
+          // Two things this ordering buys, both load-bearing. Arming the deadline first would leave
+          // the timer live after such a throw, to fire a spurious failure a minute later. And
+          // `break` here is what keeps that from happening now: without it control would fall
+          // through and arm a deadline on a request that has already settled.
+          //
+          // Nothing can settle before the timer exists, because iframe-phone never invokes the
+          // callback synchronously — it stores the callback, arms its own 2s timer, then posts.
+          try {
+            connection.call(message, handleResponse);
+          } catch (error) {
+            settleFailure(error);
+            break;
+          }
 
           // Capture the deadline this request was given, so a later setRequestTimeout() can't
           // make the reported duration disagree with the timer that actually fired.
           const timeout = requestTimeout;
           timeoutTimer = setTimeout(function () {
-            settle(reject, "sendRequest: CODAP request exceeded " + timeout + "ms: " +
+            stats.countDiReqDeadlineExceeded++;
+            settleFailure("sendRequest: CODAP request exceeded " + timeout + "ms: " +
                 JSON.stringify(message));
           }, timeout);
         } else {
           // Nothing will ever call back, so settle now rather than leaving the caller waiting
           // forever — the same guarantee the deadline provides once a request is in flight.
-          settle(reject, "sendRequest on non-existent CODAP connection: " + JSON.stringify(message));
+          settleFailure("sendRequest on non-existent CODAP connection: " + JSON.stringify(message));
         }
     }
   });
@@ -394,6 +471,10 @@ export const codapInterface = {
       // initialize connection
       connection = new IframePhoneRpcEndpoint(
           notificationHandler, "data-interactive", window.parent);
+      // Reset the state, so that initializing again after destroy() works. Without this the
+      // handshake below would be refused by the `case "closed"` branch in issueRequest, and the
+      // connection could never be reestablished.
+      connectionState = "preinit";
 
       if (!config.customInteractiveStateHandler) {
         this_.on("get", "interactiveState", function () {
@@ -468,25 +549,45 @@ export const codapInterface = {
     interactiveState = Object.assign(interactiveState, iInteractiveState);
   },
 
+  /**
+   * Tears down the connection to CODAP. Requests issued afterwards are refused rather than sent;
+   * `init()` can be called again to reconnect.
+   */
   destroy () {
-    // TODO: settle the requests still in flight. Nulling the connection leaves each of them to wait
-    // out its full deadline — a minute in which the caller holds its payload alive after the plugin
-    // is gone, ending in a rejection that can surface against a re-initialized instance. They used
-    // to fail within iframe-phone's ~2s by accident. Settling them needs a registry of in-flight
-    // requests, since `isSettled` and `timeoutTimer` are locals inside each issueRequest executor;
-    // a destroyed connection should refuse new requests too, which `connectionState = "closed"`
-    // would do.
+    // TODO: settle the requests still in flight. Each of them waits out its full deadline instead —
+    // a minute in which the caller holds its payload alive after the plugin is gone, ending in a
+    // rejection that can surface against a re-initialized instance. They used to fail within
+    // iframe-phone's ~2s by accident. Settling them needs a registry of in-flight requests, since
+    // `isSettled` and `timeoutTimer` are locals inside each issueRequest executor.
     connection = null;
+    // Report the state the caller put us in, so getConnectionState() is honest after teardown and
+    // new requests are refused rather than reaching a null connection. init() resets this.
+    connectionState = "closed";
   },
 
   /**
    * Sends a request to CODAP. The format of the message is as defined in
    * {@link https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-API}.
    *
-   * @param message {String}
-   * @param callback {function(response, request)} Optional callback to handle
-   *    the CODAP response. Note both the response and the initial request will
-   *    sent.
+   * A request waits up to `getRequestTimeout()` milliseconds (60 seconds by default) for CODAP to
+   * answer. It settles exactly once, and both the promise and the callback report every outcome:
+   *
+   * - **CODAP answered:** the promise resolves with the response and the callback receives it. That
+   *   includes `{success: false}`, which means CODAP answered and declined — a resolved promise, not
+   *   a rejected one.
+   * - **The request failed:** the promise rejects with an `Error` and the callback is invoked with
+   *   `undefined`. This covers exceeding the deadline, there being no connection to send on (before
+   *   `initializePlugin()` or after `destroy()`), and CODAP answering with no value at all.
+   *
+   * The callback is invoked exactly once, after the promise has settled. A callback written as
+   * `result.success` therefore has to handle the `undefined` it receives on failure. Note that the
+   * promise rejects whether or not a callback is passed, so it still needs a `.catch` to avoid an
+   * unhandled rejection. An exception thrown by the callback itself is rethrown as an uncaught error
+   * rather than failing the request, which has already settled by then.
+   *
+   * @param message {Object} The request, as in the Data Interactive API.
+   * @param callback {function(response, request)} Optional. Receives the response, or `undefined`
+   *    if the request failed, followed by the original request.
    *
    * @return {Promise} The promise of the response from CODAP.
    */

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -63,6 +63,11 @@ let connectionState = "preinit";
  * closed, iframe removed) still can't leave callers awaiting forever.
  */
 const kDefaultRequestTimeout = 60000;
+/**
+ * setTimeout stores its delay in a signed 32-bit int, so a larger delay overflows and the timer
+ * fires immediately.
+ */
+const kMaxRequestTimeout = 2 ** 31 - 1;
 let requestTimeout = kDefaultRequestTimeout;
 
 const stats = {
@@ -189,6 +194,100 @@ function notificationHandler (request: { action: any; resource: any; values: any
   return callback(returnMessage);
 }
 
+interface IRequestOptions {
+  /** Invoked with the response on success and with `undefined` on failure. */
+  callback?: any
+  /**
+   * Reject as soon as iframe-phone reports no reply, instead of waiting out `requestTimeout`.
+   *
+   * Set only for the handshake in `init()`. Everywhere else a request that draws no reply within
+   * iframe-phone's advisory 2s is assumed to be in flight and still coming; during the handshake
+   * there is no such assumption to make, so silence means nothing is listening. This is a property
+   * of the individual request rather than of the connection state, so an ordinary request issued
+   * while the handshake is outstanding is still treated as an ordinary request.
+   */
+  failFastWithoutReply?: boolean
+}
+
+/**
+ * Issues a request to CODAP and returns a promise of the response.
+ */
+function issueRequest (message: any, options: IRequestOptions = {}) {
+  const { callback, failFastWithoutReply = false } = options;
+  return new Promise(function (resolve, reject) {
+    let isSettled = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // A request settles exactly once, and the caller's callback is notified on every outcome:
+    // with the response on success, and with `undefined` on failure. Callers may pass a callback
+    // and discard the promise — several helpers in this package do — so for them the callback is
+    // the only signal that the request is over.
+    function settle (settleFn: (value?: any) => void, value: any, callbackResponse?: any) {
+      if (isSettled) { return; }
+      isSettled = true;
+      if (timeoutTimer !== undefined) { clearTimeout(timeoutTimer); }
+      settleFn(value);
+      if (callback) {
+        // A callback written for the success case may not expect `undefined`; a throw from it
+        // must not escape into the timer or the promise executor that settled the request.
+        try {
+          callback(callbackResponse, message);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.warn("codapInterface: request callback threw", error);
+        }
+      }
+    }
+
+    function handleResponse (response: {success: boolean} | undefined) {
+      if (response === undefined) {
+        // iframe-phone's advisory timer expired; the reply is still coming. See kDefaultRequestTimeout.
+        stats.countDiRplTimeout++;
+        if (failFastWithoutReply) {
+          settle(reject, "handleResponse: CODAP request timed out: " + JSON.stringify(message));
+        }
+        return;
+      }
+      connectionState = "active";
+      if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
+      settle(resolve, response, response);
+    }
+
+    switch (connectionState) {
+      case "closed": // log the message and ignore
+        // console.warn('sendRequest on closed CODAP connection: ' + JSON.stringify(message));
+        settle(reject, "sendRequest on closed CODAP connection: " + JSON.stringify(message));
+        break;
+      case "preinit": // warn, but issue request.
+        // console.log('sendRequest on not yet initialized CODAP connection: ' +
+            // JSON.stringify(message));
+        /* falls through */
+      default:
+        if (connection) {
+          stats.countDiReq++;
+          stats.timeDiLastReq = new Date();
+          if (!stats.timeDiFirstReq) {
+            stats.timeDiFirstReq = stats.timeDiLastReq;
+          }
+
+          // Capture the deadline this request was given, so a later setRequestTimeout() can't
+          // make the reported duration disagree with the timer that actually fired.
+          const timeout = requestTimeout;
+          timeoutTimer = setTimeout(function () {
+            settle(reject, "sendRequest: CODAP request exceeded " + timeout + "ms: " +
+                JSON.stringify(message));
+          }, timeout);
+
+          connection.call(message, handleResponse);
+        } else {
+          // Nothing will ever call back, so settle now rather than leaving the caller waiting
+          // forever — the same guarantee the deadline provides once a request is in flight.
+          settle(reject, "sendRequest on non-existent CODAP connection: " + JSON.stringify(message));
+        }
+    }
+  });
+}
+
 export const codapInterface = {
   /**
    * Connection statistics
@@ -265,7 +364,7 @@ export const codapInterface = {
 
       // console.log('sending interactiveState: ' + JSON.stringify(this_.getInteractiveState));
       // update, then get the interactiveFrame.
-      return this_.sendRequest([updateFrameReq, getFrameReq])
+      return issueRequest([updateFrameReq, getFrameReq], { failFastWithoutReply: true })
         .then(getFrameRespHandler as any, reject);
     }.bind(this));
   },
@@ -277,18 +376,29 @@ export const codapInterface = {
   getConnectionState () {return connectionState;},
 
   /**
-   * How long, in milliseconds, to wait for a CODAP response before rejecting a request.
-   * Raise this for plugins that issue requests over very large datasets; lower it if a caller
-   * needs to fail fast. See `requestTimeout` for why this is not iframe-phone's 2s timer.
+   * How long, in milliseconds, a request waits for a CODAP response before it is rejected.
+   * Defaults to 60000. Raise it for plugins that issue requests over very large datasets; lower it
+   * if a caller needs to fail fast.
+   *
+   * This is deliberately much longer than the 2s timer inside iframe-phone, which reports that no
+   * reply has arrived yet without cancelling the request — a large request routinely takes longer
+   * than that and still succeeds.
    */
   getRequestTimeout () {return requestTimeout;},
 
   /**
-   * A non-finite or non-positive value falls back to the default: setTimeout treats NaN and
-   * negative delays as 0, which would silently make every subsequent request fail at once.
+   * Sets how long, in milliseconds, a request waits for a CODAP response before it is rejected.
+   * Applies to requests issued after the call; requests already in flight keep the value they
+   * were given.
+   *
+   * A non-finite or non-positive value falls back to the default of 60000, and larger values are
+   * clamped: setTimeout treats NaN and negative delays as 0 and overflows above its 32-bit
+   * ceiling, either of which would silently make every subsequent request fail at once.
    */
   setRequestTimeout (timeout: number) {
-    requestTimeout = Number.isFinite(timeout) && timeout > 0 ? timeout : kDefaultRequestTimeout;
+    requestTimeout = Number.isFinite(timeout) && timeout > 0
+                      ? Math.min(timeout, kMaxRequestTimeout)
+                      : kDefaultRequestTimeout;
   },
 
   getStats () {
@@ -336,76 +446,7 @@ export const codapInterface = {
    * @return {Promise} The promise of the response from CODAP.
    */
   sendRequest (message: any, callback?: any) {
-    return new Promise(function (resolve, reject){
-      let isSettled = false;
-      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-
-      // A request settles exactly once. Returns whether this call is the one that settled it, so
-      // the caller's callback is notified once, and only for the outcome the promise reports.
-      function settle (settleFn: (value?: any) => void, value: any) {
-        if (isSettled) { return false; }
-        isSettled = true;
-        if (timeoutTimer !== undefined) { clearTimeout(timeoutTimer); }
-        settleFn(value);
-        return true;
-      }
-
-      function handleResponse (request: any, response: {success: boolean} | undefined, cb: (arg0: any, arg1: any) => void) {
-        if (response === undefined) {
-          // iframe-phone's 2s timer expired. That timer is advisory: the request has not been
-          // cancelled and this same callback will be invoked again with the real reply once CODAP
-          // finishes, so record the delay and keep waiting rather than reporting a failure and
-          // discarding a result that is still coming. See `requestTimeout` above.
-          stats.countDiRplTimeout++;
-          // Until CODAP has answered something, though, that timer is the liveness signal it was
-          // designed to be: no reply is the evidence that nothing is listening. Keep failing fast
-          // there so a plugin loaded outside CODAP learns in seconds rather than a minute.
-          if (connectionState === "preinit") {
-            settle(reject, "handleResponse: CODAP request timed out: " + JSON.stringify(request));
-          }
-          return;
-        }
-        connectionState = "active";
-        if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
-        if (settle(resolve, response) && cb) {
-          cb(response, request);
-        }
-      }
-      switch (connectionState) {
-        case "closed": // log the message and ignore
-          // console.warn('sendRequest on closed CODAP connection: ' + JSON.stringify(message));
-          settle(reject, "sendRequest on closed CODAP connection: " + JSON.stringify(message));
-          break;
-        case "preinit": // warn, but issue request.
-          // console.log('sendRequest on not yet initialized CODAP connection: ' +
-              // JSON.stringify(message));
-          /* falls through */
-        default:
-          if (connection) {
-            stats.countDiReq++;
-            stats.timeDiLastReq = new Date();
-            if (!stats.timeDiFirstReq) {
-              stats.timeDiFirstReq = stats.timeDiLastReq;
-            }
-
-            // Capture the deadline this request was given, so a later setRequestTimeout() can't
-            // make the reported duration disagree with the timer that actually fired.
-            const timeout = requestTimeout;
-            timeoutTimer = setTimeout(function () {
-              settle(reject, "sendRequest: CODAP request exceeded " + timeout + "ms: " +
-                  JSON.stringify(message));
-            }, timeout);
-
-            connection.call(message, function (response: any) {
-              handleResponse(message, response, callback);
-            });
-          } else {
-            // Nothing will ever call back, so settle now rather than leaving the caller waiting
-            // forever — the same guarantee the hard timeout provides once a request is in flight.
-            settle(reject, "sendRequest on non-existent CODAP connection: " + JSON.stringify(message));
-          }
-      }
-    });
+    return issueRequest(message, { callback });
   },
 
   /**

--- a/src/api/codap-interface.ts
+++ b/src/api/codap-interface.ts
@@ -51,6 +51,20 @@ let connection: { call: (arg0: any, arg1: (response: any) => void) => void; } | 
 
 let connectionState = "preinit";
 
+/**
+ * How long to wait for a CODAP response before giving up on a request.
+ *
+ * iframe-phone imposes its own hard-coded 2s deadline on every RPC, but that timer is a liveness
+ * probe rather than a completion deadline: it neither cancels the request nor forgets the callback,
+ * and it still delivers the real reply to that same callback once CODAP finishes. A request that
+ * legitimately takes longer than 2s — creating several thousand items, say — is therefore reported
+ * as failed while the result that is about to arrive is discarded. We wait for the real reply
+ * instead, bounded by this much longer deadline so that a CODAP which never replies at all (page
+ * closed, iframe removed) still can't leave callers awaiting forever.
+ */
+const kDefaultRequestTimeout = 60000;
+let requestTimeout = kDefaultRequestTimeout;
+
 const stats = {
   countDiReq: 0,
   countDiRplSuccess: 0,
@@ -262,6 +276,15 @@ export const codapInterface = {
    */
   getConnectionState () {return connectionState;},
 
+  /**
+   * How long, in milliseconds, to wait for a CODAP response before rejecting a request.
+   * Raise this for plugins that issue requests over very large datasets; lower it if a caller
+   * needs to fail fast. See `requestTimeout` for why this is not iframe-phone's 2s timer.
+   */
+  getRequestTimeout () {return requestTimeout;},
+
+  setRequestTimeout (timeout: number) {requestTimeout = timeout;},
+
   getStats () {
     return stats;
   },
@@ -308,24 +331,38 @@ export const codapInterface = {
    */
   sendRequest (message: any, callback?: any) {
     return new Promise(function (resolve, reject){
+      let isSettled = false;
+      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+      // A request settles exactly once. Returns whether this call is the one that settled it, so
+      // the caller's callback is notified once, and only for the outcome the promise reports.
+      function settle (settleFn: (value?: any) => void, value: any) {
+        if (isSettled) { return false; }
+        isSettled = true;
+        if (timeoutTimer !== undefined) { clearTimeout(timeoutTimer); }
+        settleFn(value);
+        return true;
+      }
+
       function handleResponse (request: any, response: {success: boolean} | undefined, cb: (arg0: any, arg1: any) => void) {
         if (response === undefined) {
-          // console.warn('handleResponse: CODAP request timed out');
-          reject("handleResponse: CODAP request timed out: " + JSON.stringify(request));
+          // iframe-phone's 2s timer expired. That timer is advisory: the request has not been
+          // cancelled and this same callback will be invoked again with the real reply once CODAP
+          // finishes, so record the delay and keep waiting rather than reporting a failure and
+          // discarding a result that is still coming. See `requestTimeout` above.
           stats.countDiRplTimeout++;
-        } else {
-          connectionState = "active";
-          if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
-          resolve(response);
+          return;
         }
-        if (cb) {
+        connectionState = "active";
+        if (response.success) { stats.countDiRplSuccess++; } else { stats.countDiRplFail++; }
+        if (settle(resolve, response) && cb) {
           cb(response, request);
         }
       }
       switch (connectionState) {
         case "closed": // log the message and ignore
           // console.warn('sendRequest on closed CODAP connection: ' + JSON.stringify(message));
-          reject("sendRequest on closed CODAP connection: " + JSON.stringify(message));
+          settle(reject, "sendRequest on closed CODAP connection: " + JSON.stringify(message));
           break;
         case "preinit": // warn, but issue request.
           // console.log('sendRequest on not yet initialized CODAP connection: ' +
@@ -338,6 +375,11 @@ export const codapInterface = {
             if (!stats.timeDiFirstReq) {
               stats.timeCodapFirstReq = stats.timeDiLastReq;
             }
+
+            timeoutTimer = setTimeout(function () {
+              settle(reject, "sendRequest: CODAP request exceeded " + requestTimeout + "ms: " +
+                  JSON.stringify(message));
+            }, requestTimeout);
 
             connection.call(message, function (response: any) {
               handleResponse(message, response, callback);

--- a/src/codap-plugin-api.ts
+++ b/src/codap-plugin-api.ts
@@ -1,4 +1,4 @@
-export {IConfig, ClientNotification, ClientHandler, RequestCallback, codapInterface} from "./api/codap-interface";
+export {IConfig, ClientNotification, ClientHandler, RequestCallback, BatchRequestCallback, codapInterface} from "./api/codap-interface";
 
 export {
   IDimensions,

--- a/src/codap-plugin-api.ts
+++ b/src/codap-plugin-api.ts
@@ -1,4 +1,4 @@
-export {IConfig, ClientNotification, ClientHandler, codapInterface} from "./api/codap-interface";
+export {IConfig, ClientNotification, ClientHandler, RequestCallback, codapInterface} from "./api/codap-interface";
 
 export {
   IDimensions,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,13 @@
   },
   "include": [
     "./src/**/*"
+  ],
+  // Keep test files out of the build output; jest's testRegex would otherwise match the compiled
+  // copies and run every suite twice. src/test is deliberately not excluded: setupTests.ts is what
+  // pulls in the ambient jest globals, and jest's testRegex doesn't match its name.
+  "exclude": [
+    "./src/**/*.spec.ts",
+    "./src/**/*.test.ts",
+    "./src/**/__tests__"
   ]
 }


### PR DESCRIPTION
## Summary

`iframe-phone` imposes a hard-coded **2000 ms** deadline on every RPC (`lib/iframe-phone-rpc-endpoint.js`), but that timer is a **liveness probe, not a completion deadline**. It does not cancel the request, does not forget the callback, and still delivers the real reply to that same callback once CODAP finishes.

`sendRequest` treated it as a failure and rejected. Two consequences:

- A slow-but-successful request was reported as failed, and the result that was already on its way was discarded -- because the promise had settled, the later `resolve()` was a no-op. **A timed-out request could never learn its true outcome.**
- Any plugin creating data in bulk hits this. It was found via SAMPLER-107, where a `createItems` measured at **11,121 ms** for 3,616 items in Safari -- 5.6x the deadline -- while CODAP processed it successfully throughout.

## What this fixes beyond the reported bug

The change started as one fix — don't treat iframe-phone's advisory 2s timeout as a request failure —
and review turned it into a stated contract for both of this library's interactions. That was worth
doing here rather than deferring, because the failure paths on `main` were not wrong by design so much
as never specified, and therefore never checked. Fifteen defects, of which the reported one is the
first:

| on `main` | how it bit a plugin |
| --- | --- |
| the advisory 2s timeout was treated as a failure | a slow but successful request was reported failed and its real result discarded |
| the callback was invoked **twice** for any request over 2s | a callback written as `result.success` threw a `TypeError` at the 2s mark, then succeeded |
| `sendRequest` with no connection never settled | the promise stayed pending forever — before `initializePlugin()`, or after `destroy()` |
| a callback's exception propagated into iframe-phone's listener | skipped that library's own `pendingCallbacks` cleanup, leaking the entry |
| a `null` reply dereferenced `.success` | threw inside the message listener, where nothing settles the request |
| `init()`'s `stateHandler` ran before `resolve` | a throwing handler left `initializePlugin()` pending forever, exception discarded |
| the saved-state merge ran before `resolve` too | a throwing getter in a restored document did the same |
| `init()` rejected with bare strings, and skipped `iCallback` on failure | two rejection shapes, and no failure signal for callback users |
| the bundled helpers discarded promises that rejected at 2s | an unhandled rejection on every slow request |
| `ensureUniqueCollectionName` read silence as "the name is free" | duplicate collections |
| `createCollectionFromAttribute` resolved on its *lookup* reply | reported success before the work happened; failures in the real steps were invisible |
| `selectSelf` read `.success` off a possibly-undefined result, and could send `component[undefined]` | a crash, or a request that cannot succeed |
| a batched reply was counted as a failure | every successful startup logged one in `getStats()` |
| `stats.timeDiFirstReq` was never set | the guard tested it but assigned `timeCodapFirstReq` |
| `getConnectionState()` advertised five states | only three are ever written, so consumers coded for two that cannot occur |

The reported bug is the one that fires on the **happy** path, which is why it surfaced: a working
plugin hits it under load. The rest need a failure first — rarer in testing, routine in use — and
several of them fail *silently*, which is worse than a crash because nobody goes looking. A
reorganization reported as done, a name reported as free, a batch reported as failed.

Still deferred, with a TODO at the site: `destroy()` neither settles requests still in flight nor
unsubscribes from iframe-phone.

## The contract

Chasing that fix through review turned this into a PR about a contract rather than a timer, so it is worth stating outright. It is published on `sendRequest`'s JSDoc, in the README, and in the CHANGELOG:

- A request **settles exactly once**.
- **CODAP answered** -> the promise resolves with the response, and the callback receives it. That includes `{success: false}`, which means CODAP answered and declined.
- **The request failed** -> the promise rejects with an `Error`, and the callback is invoked with `undefined`. Every failure reports both ways: exceeding the deadline, no connection to send on, CODAP answering with no value, and the send itself throwing.
- **No deadline timer outlives a settled request.**
- An exception thrown by the caller's own callback is **not** a failure of the request. It is rethrown from a microtask, so it stays clear of iframe-phone's listener, the deadline timer and the promise executor, while remaining an uncaught error `window.onerror` and error reporters can see.

Two things follow from taking that seriously. The callback parameter is **typed**, so a callback that cannot accept `undefined` does not compile -- see the Breaking notes. And `init()`, which does not go through `sendRequest`, holds the same line separately: it always settles, reports failure to its callback as well as its promise, rejects with an `Error`, and leaves the plugin able to retry.

## Changes

- `sendRequest` ignores the advisory timeout (still counted, as `countDiRplTimeout`) and settles on the real reply.
- Adds its own much longer deadline -- **60 s default, configurable** via `setRequestTimeout()` / `getRequestTimeout()` -- so a CODAP that never replies at all can't leave callers awaiting forever. An invalid value (non-finite or non-positive) falls back to the default, and a value above `setTimeout`'s 32-bit ceiling is clamped, since it would otherwise overflow and fire immediately.
- **The handshake still fails fast**, as a property of the individual request rather than of the connection state, so an ordinary request issued while the handshake is outstanding is unaffected. This is a deliberate trade, not a safe inference: iframe-phone buffers until the parent answers its repeated "hello", so a slow parent looks like no parent. The alternative is a plugin loaded outside CODAP waiting a full minute to find out, and a plugin that does load can retry.
- **A reply carrying no value is distinguished from the advisory probe.** Both arrive as `undefined`; the library passes a second argument for the probe alone, which the old one-argument annotation for `connection` hid. An empty reply therefore still fails immediately, as it did in 0.1.9, rather than waiting out the new deadline. A `null` reply is treated the same, where reading `.success` off it used to throw inside iframe-phone's listener.
- **Failures reject with an `Error`**, so a consumer's `.catch` gets a stack and every rejection from the module has one shape. Failure messages are built through a guarded `describeMessage`: a cyclic or BigInt-bearing message is structured-cloneable and so is genuinely sent, and `JSON.stringify` throwing while *describing* it used to leave the request settled by nothing at all.
- `connection.call` is wrapped, and the deadline is armed inside the same `try` after it. A synchronous `DataCloneError` therefore settles through the contract instead of escaping the executor, and skips arming a timer structurally rather than by an ordering a later edit could get wrong.
- **`init()` settles before handing control to the caller's handlers.** `stateHandler` used to run before the handshake resolved, so a throw from it left `initializePlugin()` pending forever with the exception discarded. A failed handshake now also closes the connection -- left in place it looked live, so every later request was sent and waited out the full 60 s -- and reports the failure to `init()`'s callback.
- `destroy()` reports the connection as `closed`, making `getConnectionState()` accurate after teardown and refusing later requests; `init()` clears that state so a plugin can reconnect. Neither inbound path will mark a torn-down connection live again.
- **`getStats()` accounts for requests, and reconciles.** `countDiReqFailed` counts every failure, `countDiReqDeadlineExceeded` the subset that ran out of time, and `countDiRplFail` now means only what its name says -- a request CODAP answered and declined. `countDiReq` minus the three outcome counters is the number still in flight. A batched request, answered with an array that has no top-level `success`, was counted as a decline however it went, so every successful `init()` handshake reported one; it now counts as the single request it was.
- **The bundled helpers handle a request that goes unanswered.** They read `.success` off the response, so an unanswered request previously surfaced as a `TypeError` -- and, where the promise was discarded, an unhandled rejection. `ensureUniqueCollectionName` uses the promise form, so a lookup that gets no answer reaches the caller rather than being read as "not found"; `selectSelf` stays fire-and-forget, reports a refusal as well as an absence, and no longer asks CODAP to select `component[undefined]`.

  `codap-helper.ts` records the rule this produced: prefer the promise form in helpers that consume the answer, since absence then arrives as a rejection rather than a silently-unchecked `undefined`.
- **`createCollectionFromAttribute` reports whether the reorganization happened.** It ran on nested callbacks and returned the promise of its first request, so it resolved with the collection lookup while the create and move steps were still outstanding, and their failures reached the caller as nothing at all. It now awaits each step and resolves with an `IResult` for the last one it reached. Return type narrows from `Promise<unknown>` to `Promise<IResult>`.
- The contract lives on `sendRequest`'s JSDoc, which is what a consumer's IDE shows -- it had been written on a module-private interface that never reaches the published declarations -- and the README says when the promise rejects, not only what the callback receives.
- Version bumped to **0.2.0**, and the CHANGELOG separates a **Breaking** section from Changed. The minor bump is what keeps those changes from arriving unasked: for a `0.x` package npm resolves `^0.1.9` to `<0.2.0`, so a consumer opts in deliberately. (Checked: `multidata-plugin`, the one known consumer of `createCollectionFromAttribute`, pins `^0.1.9` and discards the resolved value, so nothing breaks until it upgrades.)

Two incidental fixes, each in its own commit: `stats.timeDiFirstReq` was never set (the guard tested it but assigned `timeCodapFirstReq`), and `tsconfig` compiled the specs into `build/`, where jest's `testRegex` matched the compiled copies and ran every suite twice. And two pre-existing README errors noticed while documenting the callback type: the install line named a package that does not exist under that name, in an example that could not run as written, and the build section described an `npm build` producing a `dist` folder that nothing creates.

## The callback type

Called out separately because it is the one change here that breaks a build rather than a run.

`sendRequest`'s second parameter was `any`, which accepted `(result: IResult) => result.success` -- the shape that throws a `TypeError` the moment a request fails. It is now the exported `RequestCallback`, whose response parameter admits `undefined`.

This was deferred twice, on the grounds that breaking a build has a wider blast radius than breaking a run and that a consumer cannot opt out of a compile error the way they can pin a version. Neither survives contact with this release. What changed here **is** the shape of that callback, so a consumer whose callbacks no longer match the expected signature should find out -- and the wide blast radius is exactly the set of callbacks that are now wrong. Nor is the opt-out missing: `^0.1.9` resolves to `<0.2.0`, so upgrading is already deliberate, and the compile error at that moment names every call site to fix. The alternative is each one throwing on a failure path that is rare in testing and common in front of users.

It is pinned at the type level rather than by inspection: the spec asserts assignability against `sendRequest`'s own parameter, so if it ever loosens back to `any` the `@ts-expect-error` stops being an error and the suite fails to compile (`TS2578`). Note which gate guards that -- `npm test`, via ts-jest, not `tsc --noEmit`, since tsconfig excludes the specs by design.

The required shape follows from the message. CODAP answers a batched request -- an array of requests -- with an array of results, so that case takes `BatchRequestCallback`, and pairing either callback with the wrong message shape does not compile. Previously `sendRequest([a, b], cb)` compiled and handed `cb` an array, where reading `result.success` gave `undefined` and a successful batch looked like a failed one -- the same class of silent wrong answer this PR is about, which is why a doc comment saying "batch through the promise" was not enough.

## Deferred

One item, recorded as a TODO at `destroy()`: teardown neither settles the requests still in flight nor unsubscribes from iframe-phone. Both need machinery this PR does not add -- a registry of in-flight requests, since `isSettled` and `timeoutTimer` are locals inside each executor, and coverage of what iframe-phone's endpoint singleton does across a disconnect/reconnect, which unit tests against a mocked endpoint cannot provide. The consequence of the second is why both inbound paths check `connection` before reporting a connection live.

`grep -rn TODO src/` returns that one line and nothing else. Everything else previously deferred has been taken: the probe/empty-reply ambiguity, the stats accounting including the batched reply, the `destroy()` connection state, the published documentation, and the callback type.

## Testing

**53 tests** across `src/api/codap-interface.spec.ts` and `src/api/codap-helper.spec.ts`.

The core of it is a block that enumerates every way a request can settle rather than checking the paths someone thought of -- CODAP answering, CODAP declining, an answer with no value, a `null` answer, the deadline passing, the send throwing, no connection, a destroyed connection, a message that cannot be serialized for its own error, a duplicated reply, a reply after the deadline, and the advisory probe, which must settle nothing. Each asserts all three parts of the contract together: how the promise settles, that the callback fired exactly once with the documented argument, and that no deadline was left behind. Two failed review rounds both turned on a path nobody had enumerated, which is what this block exists to prevent.

The rest covers the timeout mechanics (configurability, invalid values, the 32-bit clamp, reporting the deadline the request was given), the callback-exception contract on its sync, async and no-connection paths, the callback type at compile time, `init()` (settling when a handler throws, failing without stranding the plugin, retry), `destroy()`, the stats counters including a batched reply, and the helpers -- including `selectSelf`, which had no coverage at all, and the boundary of `ensureUniqueCollectionName`'s candidate range.

Every behavioural fix was verified non-vacuous by reverting it individually and confirming its test fails. That is also how two tests of my own were caught passing either way.

Also verified end-to-end in Safari against the Sampler plugin (via `yalc`), reproducing the original failure and confirming it no longer occurs.

Relates to SAMPLER-107. CODAP-side performance findings are tracked separately in CODAP-1476.

